### PR TITLE
Fix packaging of easy schema

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,11 +27,11 @@
     <artifactId>easy-schema</artifactId>
     <name>EASY Schema Definitions</name>
     <description>Collection of metadata schema's used by EASY</description>
-    <version>1.2</version>
+    <version>1.x-SNAPSHOT</version>
     <inceptionYear>2015-2016</inceptionYear>
     <scm>
         <developerConnection>scm:git:https://github.com/DANS-KNAW/${project.artifactId}</developerConnection>
-        <tag>v1.2</tag>
+        <tag>HEAD</tag>
     </scm>
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -27,11 +27,11 @@
     <artifactId>easy-schema</artifactId>
     <name>EASY Schema Definitions</name>
     <description>Collection of metadata schema's used by EASY</description>
-    <version>1.x-SNAPSHOT</version>
+    <version>1.1</version>
     <inceptionYear>2015-2016</inceptionYear>
     <scm>
         <developerConnection>scm:git:https://github.com/DANS-KNAW/${project.artifactId}</developerConnection>
-        <tag>HEAD</tag>
+        <tag>v1.1</tag>
     </scm>
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -27,11 +27,11 @@
     <artifactId>easy-schema</artifactId>
     <name>EASY Schema Definitions</name>
     <description>Collection of metadata schema's used by EASY</description>
-    <version>1.x-SNAPSHOT</version>
+    <version>1.2</version>
     <inceptionYear>2015-2016</inceptionYear>
     <scm>
         <developerConnection>scm:git:https://github.com/DANS-KNAW/${project.artifactId}</developerConnection>
-        <tag>HEAD</tag>
+        <tag>v1.2</tag>
     </scm>
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -27,11 +27,11 @@
     <artifactId>easy-schema</artifactId>
     <name>EASY Schema Definitions</name>
     <description>Collection of metadata schema's used by EASY</description>
-    <version>1.1</version>
+    <version>1.x-SNAPSHOT</version>
     <inceptionYear>2015-2016</inceptionYear>
     <scm>
         <developerConnection>scm:git:https://github.com/DANS-KNAW/${project.artifactId}</developerConnection>
-        <tag>v1.1</tag>
+        <tag>HEAD</tag>
     </scm>
     <build>
         <plugins>

--- a/src/main/assembly/bin.xml
+++ b/src/main/assembly/bin.xml
@@ -22,10 +22,11 @@
         xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
     <id>bin</id>
     <!--
-        No base directory configuration. For easy-schema we don't want the name of the base directory to include
+        For easy-schema we don't want the name of the base directory to include
         the version number (e.g., "easy-schema-1.x-SNAPSHOT"). It should be just "easy-schema" to facilitate the
         usage of this package as a maven resource dependency. (See the easy-app/lib/dmm project for example.)
     -->
+    <baseDirectory>${project.artifactId}</baseDirectory>
     <formats>
         <format>tar.gz</format>
     </formats>


### PR DESCRIPTION
 Fixed problem with base directory of easy-schema. The default configured in dans-prototype is to create a base directory in the tar.gz file that includes the version number e.g., easy-schema-1.x-SNAPSHOT. This is what we usually want, because it makes deploying multiple versions of a module alongside each other easier. For easy-schema we do not want this, because it makes both deploying it to the production maven repo AND using it as a testing dependency harder. The solution turned out to be a simple change to the assembly descriptor.

@lindareijnhoudt @jo-pol @ekoi @rvanheest @PaulBoon  for review.