### PR TITLE
EASY-1017 allow Envelope in dcx-gml:spatial (phase 1)

### DIFF
--- a/src/main/assembly/dist/dcx/2016/dcx-gml.xsd
+++ b/src/main/assembly/dist/dcx/2016/dcx-gml.xsd
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2015-2016 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:dcx="http://easy.dans.knaw.nl/schemas/dcx/"
+           xmlns:dcx-gml="http://easy.dans.knaw.nl/schemas/dcx/gml/"
+           xmlns:dcterms="http://purl.org/dc/terms/"
+           xmlns:gml="http://www.opengis.net/gml"
+           targetNamespace="http://easy.dans.knaw.nl/schemas/dcx/gml/"
+           elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+    <!-- =================================================================================== -->
+    <xs:annotation>
+        <xs:documentation xml:lang="en">Enabling the use of GML 3.1.1 Simplified Features profile Levels 0 and 1.
+        </xs:documentation>
+    </xs:annotation>
+
+    <!-- =================================================================================== -->
+    <xs:import namespace="http://easy.dans.knaw.nl/schemas/dcx/"
+               schemaLocation="http://easy.dans.knaw.nl/schemas/dcx/2012/10/dcx.xsd"/>
+    <xs:import namespace="http://purl.org/dc/terms/"
+               schemaLocation="http://dublincore.org/schemas/xmls/qdc/dcterms.xsd"/>
+    <xs:import namespace="http://www.opengis.net/gml"
+               schemaLocation="http://schemas.opengis.net/gml/3.1.1/profiles/gmlsfProfile/1.0.0/gmlsf.xsd"/>
+
+    <!-- =================================================================================== -->
+    <xs:element name="spatial" substitutionGroup="dcterms:spatial" type="dcx-gml:SimpleGMLType">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                Extension of dcterms:spatial.
+
+                This element allows the use of GML 3.1.1 Simplified Features profile Levels 0 and 1.
+
+                See also: http://purl.org/dc/terms/spatial
+            </xs:documentation>
+        </xs:annotation>
+    </xs:element>
+
+    <!-- =================================================================================== -->
+    <xs:complexType name="SimpleGMLType">
+        <xs:complexContent>
+            <xs:extension base="dcx:ElementsOnlyNoLanguageAttributeType">
+                <xs:choice>
+                    <xs:element ref="gml:_Geometry" minOccurs="1"/>
+                    <xs:element ref="gml:boundedBy" minOccurs="1"/>
+                </xs:choice>
+                <xs:attribute name="srsName" type="xs:anyURI" default="http://www.opengis.net/def/crs/EPSG/0/4326">
+                    <xs:annotation>
+                        <xs:documentation xml:lang="en">
+                            Default coordinate reference system is WGS84 (urn:ogc:def:crs:EPSG::4326),
+                            "Used by the GPS satellite navigation system and for NATO military geodetic surveying."
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <!-- =================================================================================== -->
+</xs:schema>

--- a/src/main/assembly/dist/docs/examples/ddm/example2.xml
+++ b/src/main/assembly/dist/docs/examples/ddm/example2.xml
@@ -26,7 +26,6 @@
 		 xmlns:dc="http://purl.org/dc/elements/1.1/"
 		 xmlns:dct="http://purl.org/dc/terms/"
 		 xmlns:dcterms="http://purl.org/dc/terms/"
-
 		 xmlns:dcmitype="http://purl.org/dc/dcmitype/"
 
 		 xsi:schemaLocation="
@@ -37,7 +36,7 @@
 		 http://easy.dans.knaw.nl/schemas/vocab/narcis-type/ http://easy.dans.knaw.nl/schemas/vocab/2015/narcis-type.xsd
 		 http://www.den.nl/standaard/166/Archeologisch-Basisregister/ http://easy.dans.knaw.nl/schemas/vocab/2012/10/abr-type.xsd
 
-		 http://www.w3.org/2001/XMLSchema-instance https://www.w3.org/2001/XMLSchema-instance
+		 http://purl.org/dc/dcmitype/ http://dublincore.org/schemas/xmls/qdc/dcterms.xsd
 		 http://purl.org/dc/terms/ http://dublincore.org/schemas/xmls/qdc/dcterms.xsd
 		 http://purl.org/dc/elements/1.1/ http://dublincore.org/schemas/xmls/qdc/dc.xsd
 ">
@@ -299,7 +298,7 @@
 			</Point>
 		</dcx-gml:spatial>
 		<dcx-gml:spatial srsName="http://www.opengis.net/def/crs/EPSG/0/28992">
-			<!-- fields with an explicit srsName will not show up -->
+			<!-- fields with an explicit srsName will not show up in EMD -->
 			<Point xmlns="http://www.opengis.net/gml">
 				<!-- Same point in Dutch National Grid (urn:ogc:def:crs:EPSG::28992).
 					The list in element pos is in the order x y [altitude]. All units in m. -->
@@ -308,6 +307,18 @@
 				<pos>83575.4 455271.2 1.12</pos>
 			</Point>
 		</dcx-gml:spatial>
+		<!--TODO when the new 2016/dcx-gml.xsd is published at http://easy.dans.knaw.nl/schemas/ -->
+		<!--<dcx-gml:spatial>-->
+		<!--<boundedBy xmlns="http://www.opengis.net/gml">-->
+		<!--<Envelope srsName="">-->
+		<!--<lowerCorner>52.07913 4.34332</lowerCorner>-->
+		<!--<upperCorner>52.08110 4.34521</upperCorner>-->
+		<!--</Envelope>-->
+		<!--</boundedBy>-->
+		<!--</dcx-gml:spatial>-->
+
+		<!-- not copied to EMD, see SWORD v1 packaging document: it has no mapping for dcterms:Box -->
+		<dcterms:spatial xsi:type="dcterms:Box">name=Western Australia; northlimit=-13.5; southlimit=-35.5; westlimit=112.5; eastlimit=129</dcterms:spatial>
 
 		<!-- Use ';' for separation of list items. Use of line breaks is allowed -->
 		<dct:tableOfContents>


### PR DESCRIPTION
@DANS-KNAW/easy 

Only when the new XSD is available at https://easy.dans.knaw.nl/schemas/index.xml I can activate the new example and officially check its validity with the tests in the legacy ddm project.