### PR TITLE
Place the EMD xsd's in the top directory.

### DIFF
--- a/src/main/assembly/dist/md/emd/eas.xsd
+++ b/src/main/assembly/dist/md/emd/eas.xsd
@@ -1,0 +1,297 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2015-2016 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    targetNamespace="http://easy.dans.knaw.nl/easy/easymetadata/eas/"
+    xmlns:eas="http://easy.dans.knaw.nl/easy/easymetadata/eas/"
+    xmlns:xml="http://www.w3.org/XML/1998/namespace" elementFormDefault="qualified" attributeFormDefault="qualified">
+
+    <xs:import schemaLocation="xml.xsd"
+        namespace="http://www.w3.org/XML/1998/namespace"/>
+
+
+    <xs:annotation>
+        <xs:documentation xml:lang="eng-usa">Element and Attribute Sets (eas) to ease the encoding
+            of easymetadata.</xs:documentation>
+    </xs:annotation>
+
+    <xs:simpleType name="date-scheme">
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="Period">
+                <xs:annotation>
+                    <xs:documentation
+                        source="http://dublincore.org/documents/2000/07/11/dcmes-qualifiers/#date">
+                        <definition>A specification of the limits of a time interval.</definition>
+                        <see-also>http://dublincore.org/documents/dcmi-period/</see-also>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="W3CDTF">
+                <xs:annotation>
+                    <xs:documentation
+                        source="http://dublincore.org/documents/2000/07/11/dcmes-qualifiers/#date">
+                        <definition>W3C Encoding rules for dates and times - a profile based on ISO
+                            8601</definition>
+                        <see-also>http://www.w3.org/TR/NOTE-datetime</see-also>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="date-format">
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="MILLISECOND"/>
+            <xs:enumeration value="SECOND"/>
+            <xs:enumeration value="MINUTE"/>
+            <xs:enumeration value="HOUR"/>
+            <xs:enumeration value="DAY"/>
+            <xs:enumeration value="MONTH"/>
+            <xs:enumeration value="YEAR"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:attribute name="identification-system" type="xs:anyURI">
+        <xs:annotation>
+            <xs:documentation>
+                <definition>The formal identification system.</definition>
+            </xs:documentation>
+        </xs:annotation>
+    </xs:attribute>
+
+    <xs:complexType name="language-tokenized-string">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute ref="xml:lang"/>
+                <xs:attribute name="schemeId" type="xs:string"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:complexType name="basic-stringtype">
+        <xs:simpleContent>
+            <xs:extension base="eas:language-tokenized-string">
+                <xs:attribute name="scheme" type="xs:token"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:complexType name="basic-datetype">
+        <xs:simpleContent>
+            <xs:extension base="eas:language-tokenized-string">
+                <xs:attribute name="scheme" type="eas:date-scheme"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:complexType name="datetype">
+        <xs:simpleContent>
+            <xs:extension base="xs:dateTime">
+                <xs:attribute name="scheme" type="eas:date-scheme" fixed="W3CDTF" use="required"/>
+                <xs:attribute name="schemeId" type="xs:string"/>
+                <xs:attribute name="format" type="eas:date-format" default="DAY"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:complexType name="basic-identifiertype">
+        <xs:simpleContent>
+            <xs:extension base="eas:language-tokenized-string">
+                <xs:attribute name="scheme" type="xs:token" default="URI"/>
+                <xs:attribute ref="eas:identification-system"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:complexType name="relationtype">
+        <xs:sequence>
+            <xs:element name="subject-title" type="eas:basic-stringtype" minOccurs="0"/>
+            <xs:element name="subject-identifier" type="eas:basic-identifiertype" minOccurs="0"/>
+            <xs:element name="subject-link" type="xs:anyURI" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="emphasis" type="xs:boolean" default="false"/>
+    </xs:complexType>
+
+    <xs:complexType name="authortype">
+        <xs:sequence>
+            <xs:element name="title" type="xs:string" minOccurs="0"/>
+            <xs:element name="initials" type="xs:string" minOccurs="0"/>
+            <xs:element name="prefix" type="xs:string" minOccurs="0"/>
+            <xs:element name="surname" type="xs:string" minOccurs="0"/>
+            <xs:element name="organization" type="xs:string" minOccurs="0"/>
+            <xs:element name="entityId" minOccurs="0">
+                <xs:complexType>
+                    <xs:simpleContent>
+                        <xs:extension base="xs:string">
+                            <xs:attribute ref="eas:identification-system"/>
+                            <xs:attribute name="scheme" type="xs:string" default="DAI"/>
+                        </xs:extension>
+                    </xs:simpleContent>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:element name="point">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="x" type="xs:string" minOccurs="0"/>
+                <xs:element name="y" type="xs:string" minOccurs="0"/>
+            </xs:sequence>
+            <xs:attribute name="scheme" type="xs:token"/>
+            <xs:attribute name="schemeId" type="xs:string"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="box">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="north" type="xs:string" minOccurs="0"/>
+                <xs:element name="east" type="xs:string" minOccurs="0"/>
+                <xs:element name="south" type="xs:string" minOccurs="0"/>
+                <xs:element name="west" type="xs:string" minOccurs="0"/>
+            </xs:sequence>
+            <xs:attribute name="scheme" type="xs:token"/>
+            <xs:attribute name="schemeId" type="xs:string"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:complexType name="spatialtype">
+        <xs:sequence>
+            <xs:element name="place" type="eas:basic-stringtype" maxOccurs="1" minOccurs="0"/>
+            <xs:choice>
+                <xs:element ref="eas:point" minOccurs="0"/>
+                <xs:element ref="eas:box" minOccurs="0"/>
+            </xs:choice>
+        </xs:sequence>
+    </xs:complexType>
+    
+    <xs:simpleType name="metadataformattype">
+        <xs:annotation>
+            <xs:documentation xml:lang="eng-usa">Type of deposit form used when the dataset was created.</xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="UNSPECIFIED">
+                <xs:annotation>
+                    <xs:documentation xml:lang="eng-usa">Deprecated.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="SOCIOLOGY">
+                <xs:annotation>
+                    <xs:documentation xml:lang="eng-usa">Deprecated.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="ARCHAEOLOGY">
+                <xs:annotation>
+                    <xs:documentation xml:lang="eng-usa">Deprecated.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="HISTORY">
+                <xs:annotation>
+                    <xs:documentation xml:lang="eng-usa">Deprecated.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="LANGUAGE_LITERATURE">
+                <xs:annotation>
+                    <xs:documentation xml:lang="eng-usa">Deprecated.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="LIFESCIENCE">
+                <xs:annotation>
+                    <xs:documentation xml:lang="eng-usa">Deprecated.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="ANY_DISCIPLINE">
+                <xs:annotation>
+                    <xs:documentation xml:lang="eng-usa">Single deposit form for all disciplines.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="pakbonstatustype">
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="NOT_IMPORTED"/>
+            <xs:enumeration value="IMPORTED"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:element name="creator" type="eas:authortype"/>
+
+    <xs:element name="contributor" type="eas:authortype"/>
+
+    <!-- date extensions -->
+
+    <xs:element name="date" type="eas:datetype"/>
+    <xs:element name="created" type="eas:datetype"/>
+    <xs:element name="valid" type="eas:datetype"/>
+    <xs:element name="available" type="eas:datetype"/>
+    <xs:element name="issued" type="eas:datetype"/>
+    <xs:element name="modified" type="eas:datetype"/>
+    <xs:element name="dateAccepted" type="eas:datetype"/>
+    <xs:element name="dateCopyrighted" type="eas:datetype"/>
+    <xs:element name="dateSubmitted" type="eas:datetype"/>
+
+    <!-- relation extensions -->
+
+    <xs:element name="relation" type="eas:relationtype"/>
+    <xs:element name="conformsTo" type="eas:relationtype"/>
+    <xs:element name="isVersionOf" type="eas:relationtype"/>
+    <xs:element name="hasVersion" type="eas:relationtype"/>
+    <xs:element name="isReplacedBy" type="eas:relationtype"/>
+    <xs:element name="replaces" type="eas:relationtype"/>
+    <xs:element name="isRequiredBy" type="eas:relationtype"/>
+    <xs:element name="requires" type="eas:relationtype"/>
+    <xs:element name="isPartOf" type="eas:relationtype"/>
+    <xs:element name="hasPart" type="eas:relationtype"/>
+    <xs:element name="isReferencedBy" type="eas:relationtype"/>
+    <xs:element name="references" type="eas:relationtype"/>
+    <xs:element name="isFormatOf" type="eas:relationtype"/>
+    <xs:element name="hasFormat" type="eas:relationtype"/>
+
+    <!-- coverage extensions -->
+
+    <xs:element name="spatial" type="eas:spatialtype"/>
+
+
+    <!--                    -->
+
+    <xs:element name="remark">
+        <xs:complexType>
+            <xs:simpleContent>
+                <xs:extension base="eas:basic-stringtype">
+                    <xs:attribute name="author"/>
+                </xs:extension>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+    
+    <xs:element name="application-specific">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="metadataformat" type="eas:metadataformattype" default="UNSPECIFIED" maxOccurs="1" minOccurs="0"/>
+                <xs:element name="pakbon-status"  type="eas:pakbonstatustype" default="NOT_IMPORTED" maxOccurs="1" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    
+    <xs:element name="etc">
+        <!-- pass in any element -->
+    </xs:element>
+
+</xs:schema>

--- a/src/main/assembly/dist/md/emd/emd.xsd
+++ b/src/main/assembly/dist/md/emd/emd.xsd
@@ -1,0 +1,267 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2015-2016 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    targetNamespace="http://easy.dans.knaw.nl/easy/easymetadata/"
+    xmlns:emd="http://easy.dans.knaw.nl/easy/easymetadata/"
+    xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/"
+    xmlns:eas="http://easy.dans.knaw.nl/easy/easymetadata/eas/" elementFormDefault="qualified" attributeFormDefault="qualified">
+
+    <xs:import schemaLocation="sdc.xsd" namespace="http://purl.org/dc/elements/1.1/"/>
+    <xs:import schemaLocation="qdc.xsd" namespace="http://purl.org/dc/terms/"/>
+    <xs:import schemaLocation="eas.xsd" namespace="http://easy.dans.knaw.nl/easy/easymetadata/eas/"/>
+
+    <xs:element name="easymetadata">
+        <xs:annotation>
+            <xs:documentation> Adhering to standards and at the same time satisfying the needs of an
+                application can be in conflict. Well categorized data can be reorganized and
+                transformed. </xs:documentation>
+            <xs:documentation>
+                <definition>Easymetadata provides containers that enable the categorization of
+                    metadata according to the well defined Dublin Core standards and that offer at
+                    the same time the freedom to model the data in a way that suites the needs of
+                    the Easy application.</definition>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="emd:title" minOccurs="0"/>
+                <xs:element ref="emd:creator" minOccurs="0"/>
+                <xs:element ref="emd:subject" minOccurs="0"/>
+                <xs:element ref="emd:description" minOccurs="0"/>
+                <xs:element ref="emd:publisher" minOccurs="0"/>
+                <xs:element ref="emd:contributor" minOccurs="0"/>
+                <xs:element ref="emd:date" minOccurs="0"/>
+                <xs:element ref="emd:type" minOccurs="0"/>
+                <xs:element ref="emd:format" minOccurs="0"/>
+                <xs:element ref="emd:identifier" minOccurs="0"/>
+                <xs:element ref="emd:source" minOccurs="0"/>
+                <xs:element ref="emd:language" minOccurs="0"/>
+                <xs:element ref="emd:relation" minOccurs="0"/>
+                <xs:element ref="emd:coverage" minOccurs="0"/>
+                <xs:element ref="emd:rights" minOccurs="0"/>
+                <xs:element ref="emd:audience" minOccurs="0"/>
+                <xs:element ref="emd:other" minOccurs="0"/>
+            </xs:sequence>
+            <xs:attribute name="version" type="xs:string" use="required"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="title">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="dc:title" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="dcterms:alternative" maxOccurs="unbounded" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="creator">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="dc:creator" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="eas:creator" maxOccurs="unbounded" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="subject">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="dc:subject" maxOccurs="unbounded" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="description">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="dc:description" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="dcterms:tableOfContents" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="dcterms:abstract" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="publisher">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="dc:publisher" maxOccurs="unbounded" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="contributor">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="dc:contributor" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="eas:contributor" maxOccurs="unbounded" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="date">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="dc:date" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="dcterms:created" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="dcterms:valid" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="dcterms:available" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="dcterms:issued" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="dcterms:modified" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="dcterms:dateAccepted" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="dcterms:dateCopyrighted" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="dcterms:dateSubmitted" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="eas:date" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="eas:created" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="eas:valid" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="eas:available" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="eas:issued" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="eas:modified" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="eas:dateAccepted" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="eas:dateCopyrighted" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="eas:dateSubmitted" maxOccurs="unbounded" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="type">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="dc:type" maxOccurs="unbounded" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="format">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="dc:format" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="dcterms:extent" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="dcterms:medium" maxOccurs="unbounded" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="identifier">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="dc:identifier" maxOccurs="unbounded" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="source">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="dc:source" maxOccurs="unbounded" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="language">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="dc:language" maxOccurs="unbounded" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="relation">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="dc:relation" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="dcterms:conformsTo" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="dcterms:isVersionOf" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="dcterms:hasVersion" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="dcterms:isReplacedBy" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="dcterms:replaces" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="dcterms:isRequiredBy" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="dcterms:requires" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="dcterms:isPartOf" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="dcterms:hasPart" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="dcterms:isReferencedBy" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="dcterms:references" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="dcterms:isFormatOf" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="dcterms:hasFormat" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="eas:relation" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="eas:conformsTo" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="eas:isVersionOf" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="eas:hasVersion" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="eas:isReplacedBy" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="eas:replaces" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="eas:isRequiredBy" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="eas:requires" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="eas:isPartOf" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="eas:hasPart" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="eas:isReferencedBy" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="eas:references" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="eas:isFormatOf" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="eas:hasFormat" maxOccurs="unbounded" minOccurs="0"/>
+
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="coverage">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="dc:coverage" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="dcterms:spatial" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="dcterms:temporal" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="eas:spatial" maxOccurs="unbounded" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="rights">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="dc:rights" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="dcterms:accessRights" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="dcterms:license" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="dcterms:rightsHolder" maxOccurs="unbounded" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="audience">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="dcterms:audience" maxOccurs="unbounded" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="other">
+        <xs:annotation>
+            <xs:documentation xml:lang="eng-usa">
+                <definition>Anything that can't be expressed in the Dublin Core Metadata Element
+                    Set, nor in the additional elements from the DCMI Metadata Terms. </definition>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="eas:remark" maxOccurs="unbounded" minOccurs="0"/>
+                <xs:element ref="eas:application-specific" maxOccurs="1" minOccurs="0"/>
+                <xs:element ref="eas:etc" maxOccurs="1" minOccurs="0"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+</xs:schema>

--- a/src/main/assembly/dist/md/emd/qdc.xsd
+++ b/src/main/assembly/dist/md/emd/qdc.xsd
@@ -1,0 +1,557 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2015-2016 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://purl.org/dc/terms/"
+    xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xml="http://www.w3.org/XML/1998/namespace"
+    xmlns:eas="http://easy.dans.knaw.nl/easy/easymetadata/eas/" elementFormDefault="qualified" attributeFormDefault="qualified">
+        
+    <xs:import schemaLocation="eas.xsd" namespace="http://easy.dans.knaw.nl/easy/easymetadata/eas/"/>
+
+    <xs:annotation>
+        <xs:documentation> Additional elements from the DCMI Metadata Terms All elements are of type
+            xs:string. Where appropriate they have an optional xml:lang attribute. Where appropriate
+            they have an optional scheme attribute. </xs:documentation>
+    </xs:annotation>
+
+    <xs:element name="alternative">
+        <xs:complexType>
+            <xs:annotation>
+                <xs:documentation
+                    source="http://dublincore.org/documents/dcmi-terms/#terms-alternative"
+                    xml:lang="eng-usa">
+                    <definition>An alternative name for the resource.</definition>
+                    <comment> The distinction between titles and alternative titles is
+                        application-specific. </comment>
+                    <refines>http://purl.org/dc/elements/1.1/title</refines>
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleContent>
+                <xs:extension base="eas:basic-stringtype"> </xs:extension>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="tableOfContents">
+        <xs:complexType>
+            <xs:annotation>
+                <xs:documentation
+                    source="http://dublincore.org/documents/dcmi-terms/#terms-tableOfContents"
+                    xml:lang="eng-usa">
+                    <definition>A list of subunits of the resource.</definition>
+                    <refines>http://purl.org/dc/elements/1.1/description</refines>
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleContent>
+                <xs:extension base="eas:basic-stringtype"> </xs:extension>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="abstract">
+        <xs:complexType>
+            <xs:annotation>
+                <xs:documentation
+                    source="http://dublincore.org/documents/dcmi-terms/#terms-abstract"
+                    xml:lang="eng-usa">
+                    <definition>A summary of the resource.</definition>
+                    <refines>http://purl.org/dc/elements/1.1/description</refines>
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleContent>
+                <xs:extension base="eas:basic-stringtype"> </xs:extension>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="created">
+        <xs:complexType>
+            <xs:annotation>
+                <xs:documentation source="http://dublincore.org/documents/dcmi-terms/#terms-created"
+                    xml:lang="eng-usa">
+                    <definition>Date of creation of the resource.</definition>
+                    <refines>http://purl.org/dc/elements/1.1/date</refines>
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleContent>
+                <xs:extension base="eas:basic-datetype"/>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="valid">
+        <xs:complexType>
+            <xs:annotation>
+                <xs:documentation source="http://dublincore.org/documents/dcmi-terms/#terms-valid"
+                    xml:lang="eng-usa">
+                    <definition>Date (often a range) of validity of a resource.</definition>
+                    <refines>http://purl.org/dc/elements/1.1/date</refines>
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleContent>
+                <xs:extension base="eas:basic-datetype"/>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="available">
+        <xs:complexType>
+            <xs:annotation>
+                <xs:documentation
+                    source="http://dublincore.org/documents/dcmi-terms/#terms-available"
+                    xml:lang="eng-usa">
+                    <definition>Date (often a range) that the resource will become or did become
+                        available.</definition>
+                    <refines>http://purl.org/dc/elements/1.1/date</refines>
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleContent>
+                <xs:extension base="eas:basic-datetype"/>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="issued">
+        <xs:complexType>
+            <xs:annotation>
+                <xs:documentation source="http://dublincore.org/documents/dcmi-terms/#terms-issued"
+                    xml:lang="eng-usa">
+                    <definition>Date of formal issuance (e.g., publication) of the resource.</definition>
+                    <refines>http://purl.org/dc/elements/1.1/date</refines>
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleContent>
+                <xs:extension base="eas:basic-datetype"/>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="modified">
+        <xs:complexType>
+            <xs:annotation>
+                <xs:documentation
+                    source="http://dublincore.org/documents/dcmi-terms/#terms-modified"
+                    xml:lang="eng-usa">
+                    <definition>Date on which the resource was changed.</definition>
+                    <refines>http://purl.org/dc/elements/1.1/date</refines>
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleContent>
+                <xs:extension base="eas:basic-datetype"/>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+    
+    <xs:element name="dateAccepted">
+        <xs:complexType>
+            <xs:annotation>
+                <xs:documentation
+                    source="http://dublincore.org/documents/dcmi-terms/#terms-dateAccepted"
+                    xml:lang="eng-usa">
+                    <definition>Date of acceptance of the resource.</definition>
+                    <refines>http://purl.org/dc/elements/1.1/date</refines>
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleContent>
+                <xs:extension base="eas:basic-datetype"/>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+    
+    <xs:element name="dateCopyrighted">
+        <xs:complexType>
+            <xs:annotation>
+                <xs:documentation
+                    source="http://dublincore.org/documents/dcmi-terms/#terms-dateCopyrighted"
+                    xml:lang="eng-usa">
+                    <definition> 	Date of copyright.</definition>
+                    <refines>http://purl.org/dc/elements/1.1/date</refines>
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleContent>
+                <xs:extension base="eas:basic-datetype"/>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="dateSubmitted">
+        <xs:complexType>
+            <xs:annotation>
+                <xs:documentation
+                    source="http://dublincore.org/documents/dcmi-terms/#terms-dateSubmitted"
+                    xml:lang="eng-usa">
+                    <definition>Date of submission of the resource.</definition>
+                    <refines>http://purl.org/dc/elements/1.1/date</refines>
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleContent>
+                <xs:extension base="eas:basic-datetype"/>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="extent">
+        <xs:complexType>
+            <xs:annotation>
+                <xs:documentation source="http://dublincore.org/documents/dcmi-terms/#terms-extent"
+                    xml:lang="eng-usa">
+                    <definition>The size or duration of the resource.</definition>
+                    <refines>http://purl.org/dc/elements/1.1/format</refines>
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleContent>
+                <xs:extension base="eas:basic-stringtype"> </xs:extension>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="medium">
+        <xs:complexType>
+            <xs:annotation>
+                <xs:documentation source="http://dublincore.org/documents/dcmi-terms/#terms-medium"
+                    xml:lang="eng-usa">
+                    <definition>The material or physical carrier of the resource.</definition>
+                    <refines>http://purl.org/dc/elements/1.1/format</refines>
+                    <comment>The default scheme is IMT, the Internet media type of the resource.
+                        see: http://www.iana.org/assignments/media-types/ </comment>
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleContent>
+                <xs:extension base="eas:basic-stringtype">
+                </xs:extension>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+    
+    <xs:element name="conformsTo">
+        <xs:complexType>
+            <xs:annotation>
+                <xs:documentation
+                    source="http://dublincore.org/documents/dcmi-terms/#terms-conformsTo"
+                    xml:lang="eng-usa">
+                    <definition>An established standard to which the described resource conforms.</definition>
+                    <refines>http://purl.org/dc/elements/1.1/relation</refines>
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleContent>
+                <xs:extension base="eas:basic-identifiertype"/>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="isVersionOf">
+        <xs:complexType>
+            <xs:annotation>
+                <xs:documentation
+                    source="http://dublincore.org/documents/dcmi-terms/#terms-isVersionOf"
+                    xml:lang="eng-usa">
+                    <definition> The described resource is a version, edition, or adaptation of the
+                        referenced resource. Changes in version imply substantive changes in content
+                        rather than differences in format. </definition>
+                    <refines>http://purl.org/dc/elements/1.1/relation</refines>
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleContent>
+                <xs:extension base="eas:basic-identifiertype"/>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="hasVersion">
+        <xs:complexType>
+            <xs:annotation>
+                <xs:documentation
+                    source="http://dublincore.org/documents/dcmi-terms/#terms-hasVersion"
+                    xml:lang="eng-usa">
+                    <definition> A related resource that is a version, edition, or adaptation of the
+                        described resource. </definition>
+                    <refines>http://purl.org/dc/elements/1.1/relation</refines>
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleContent>
+                <xs:extension base="eas:basic-identifiertype"/>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="isReplacedBy">
+        <xs:complexType>
+            <xs:annotation>
+                <xs:documentation
+                    source="http://dublincore.org/documents/dcmi-terms/#terms-isReplacedBy"
+                    xml:lang="eng-usa">
+                    <definition> A related resource that supplants, displaces, or supersedes the
+                        described resource. </definition>
+                    <refines>http://purl.org/dc/elements/1.1/relation</refines>
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleContent>
+                <xs:extension base="eas:basic-identifiertype"/>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="replaces">
+        <xs:complexType>
+            <xs:annotation>
+                <xs:documentation
+                    source="http://dublincore.org/documents/dcmi-terms/#terms-replaces"
+                    xml:lang="eng-usa">
+                    <definition> A related resource that is supplanted, displaced, or superseded by
+                        the described resource. </definition>
+                    <refines>http://purl.org/dc/elements/1.1/relation</refines>
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleContent>
+                <xs:extension base="eas:basic-identifiertype"/>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="isRequiredBy">
+        <xs:complexType>
+            <xs:annotation>
+                <xs:documentation
+                    source="http://dublincore.org/documents/dcmi-terms/#terms-isRequiredBy"
+                    xml:lang="eng-usa">
+                    <definition> A related resource that requires the described resource to support
+                        its function, delivery, or coherence. </definition>
+                    <refines>http://purl.org/dc/elements/1.1/relation</refines>
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleContent>
+                <xs:extension base="eas:basic-identifiertype"/>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="requires">
+        <xs:complexType>
+            <xs:annotation>
+                <xs:documentation
+                    source="http://dublincore.org/documents/dcmi-terms/#terms-requires"
+                    xml:lang="eng-usa">
+                    <definition> A related resource that is required by the described resource to
+                        support its function, delivery, or coherence. </definition>
+                    <refines>http://purl.org/dc/elements/1.1/relation</refines>
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleContent>
+                <xs:extension base="eas:basic-identifiertype"/>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="isPartOf">
+        <xs:complexType>
+            <xs:annotation>
+                <xs:documentation
+                    source="http://dublincore.org/documents/dcmi-terms/#terms-isPartOf"
+                    xml:lang="eng-usa">
+                    <definition> A related resource in which the described resource is physically or
+                        logically included. </definition>
+                    <refines>http://purl.org/dc/elements/1.1/relation</refines>
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleContent>
+                <xs:extension base="eas:basic-identifiertype"/>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="hasPart">
+        <xs:complexType>
+            <xs:annotation>
+                <xs:documentation source="http://dublincore.org/documents/dcmi-terms/#terms-hasPart"
+                    xml:lang="eng-usa">
+                    <definition> A related resource that is included either physically or logically
+                        in the described resource. </definition>
+                    <refines>http://purl.org/dc/elements/1.1/relation</refines>
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleContent>
+                <xs:extension base="eas:basic-identifiertype"/>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="isReferencedBy">
+        <xs:complexType>
+            <xs:annotation>
+                <xs:documentation
+                    source="http://dublincore.org/documents/dcmi-terms/#terms-isReferencedBy"
+                    xml:lang="eng-usa">
+                    <definition> The described resource is referenced, cited, or otherwise pointed
+                        to by the referenced resource. </definition>
+                    <refines>http://purl.org/dc/elements/1.1/relation</refines>
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleContent>
+                <xs:extension base="eas:basic-identifiertype"/>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="references">
+        <xs:complexType>
+            <xs:annotation>
+                <xs:documentation
+                    source="http://dublincore.org/documents/dcmi-terms/#terms-references"
+                    xml:lang="eng-usa">
+                    <definition> The described resource references, cites, or otherwise points to
+                        the referenced resource. </definition>
+                    <refines>http://purl.org/dc/elements/1.1/relation</refines>
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleContent>
+                <xs:extension base="eas:basic-identifiertype"/>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="isFormatOf">
+        <xs:complexType>
+            <xs:annotation>
+                <xs:documentation
+                    source="http://dublincore.org/documents/dcmi-terms/#terms-isFormatOf"
+                    xml:lang="eng-usa">
+                    <definition> The described resource is the same intellectual content of the
+                        referenced resource, but presented in another format. </definition>
+                    <refines>http://purl.org/dc/elements/1.1/relation</refines>
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleContent>
+                <xs:extension base="eas:basic-identifiertype"/>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="hasFormat">
+        <xs:complexType>
+            <xs:annotation>
+                <xs:documentation
+                    source="http://dublincore.org/documents/dcmi-terms/#terms-hasFormat"
+                    xml:lang="eng-usa">
+                    <definition> The described resource pre-existed the referenced resource, which
+                        is essentially the same intellectual content presented in another format. </definition>
+                    <refines>http://purl.org/dc/elements/1.1/relation</refines>
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleContent>
+                <xs:extension base="eas:basic-identifiertype"/>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="spatial">
+        <xs:complexType>
+            <xs:annotation>
+                <xs:documentation source="http://dublincore.org/documents/dcmi-terms/#terms-spatial"
+                    xml:lang="eng-usa">
+                    <definition> Spatial characteristics of the intellectual content of the resoure. </definition>
+                    <refines>http://purl.org/dc/elements/1.1/coverage</refines>
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleContent>
+                <xs:extension base="eas:basic-stringtype"> </xs:extension>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="temporal">
+        <xs:complexType>
+            <xs:annotation>
+                <xs:documentation
+                    source="http://dublincore.org/documents/dcmi-terms/#terms-temporal"
+                    xml:lang="eng-usa">
+                    <definition> Temporal characteristics of the intellectual content of the
+                        resource. </definition>
+                    <refines>http://purl.org/dc/elements/1.1/coverage</refines>
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleContent>
+                <xs:extension base="eas:basic-stringtype"> </xs:extension>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="accessRights">
+        <xs:complexType>
+            <xs:annotation>
+                <xs:documentation
+                    source="http://dublincore.org/documents/dcmi-terms/#terms-accessRights"
+                    xml:lang="eng-usa">
+                    <definition> Information about who can access the resource or an indication of
+                        its security status. </definition>
+                    <refines>http://purl.org/dc/elements/1.1/rights</refines>
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleContent>
+                <xs:extension base="eas:basic-stringtype"> </xs:extension>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="license">
+        <xs:complexType>
+            <xs:annotation>
+                <xs:documentation
+                    source="http://dublincore.org/documents/dcmi-terms/#terms-accessRights"
+                    xml:lang="eng-usa">
+                    <definition> A legal document giving official permission to do something with
+                        the resource. </definition>
+                    <refines>http://purl.org/dc/elements/1.1/rights</refines>
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleContent>
+                <xs:extension base="eas:basic-stringtype"> </xs:extension>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+    
+    <xs:element name="rightsHolder">
+        <xs:complexType>
+            <xs:annotation>
+                <xs:documentation
+                    source="http://dublincore.org/documents/dcmi-terms/#terms-rightsHolder"
+                    xml:lang="eng-usa">
+                    <definition>A person or organization owning or managing rights over the resource.</definition>
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleContent>
+                <xs:extension base="eas:basic-stringtype"> </xs:extension>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="audience">
+        <xs:complexType>
+            <xs:annotation>
+                <xs:documentation
+                    source="http://dublincore.org/documents/dcmi-terms/#terms-audience"
+                    xml:lang="eng-usa">
+                    <definition> A class of entity for whom the resource is intended or useful.
+                    </definition>
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleContent>
+                <xs:extension base="eas:basic-stringtype"> </xs:extension>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+
+</xs:schema>

--- a/src/main/assembly/dist/md/emd/sdc.xsd
+++ b/src/main/assembly/dist/md/emd/sdc.xsd
@@ -1,0 +1,301 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2015-2016 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    targetNamespace="http://purl.org/dc/elements/1.1/" xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:xml="http://www.w3.org/XML/1998/namespace"
+    xmlns:eas="http://easy.dans.knaw.nl/easy/easymetadata/eas/" elementFormDefault="qualified" attributeFormDefault="qualified">
+        
+    <xs:import schemaLocation="eas.xsd" namespace="http://easy.dans.knaw.nl/easy/easymetadata/eas/"/>
+
+    <xs:annotation>
+        <xs:documentation> The 15 elements of the Dublin Core Metadata Element Set (DCMES). All
+            elements are of type xs:string. Where appropriate they have an optional xml:lang
+            attribute. Where appropriate they have an optional scheme attribute. </xs:documentation>
+    </xs:annotation>
+
+    <xs:element name="title">
+        <xs:complexType>
+            <xs:annotation>
+                <xs:documentation source="http://dublincore.org/documents/dcmi-terms/#terms-title"
+                    xml:lang="eng-usa">
+                    <definition>A name given to the resource.</definition>
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleContent>
+                <xs:extension base="eas:basic-stringtype"> </xs:extension>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="creator">
+        <xs:complexType>
+            <xs:annotation>
+                <xs:documentation source="http://dublincore.org/documents/dcmi-terms/#terms-creator"
+                    xml:lang="eng-usa">
+                    <definition>An entity primarily responsible for making the resource.</definition>
+                    <comment> Examples of a Creator include a person, an organization, or a service.
+                        Typically, the name of a Creator should be used to indicate the entity.
+                    </comment>
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleContent>
+                <xs:extension base="eas:basic-stringtype"> </xs:extension>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="subject">
+        <xs:complexType>
+            <xs:annotation>
+                <xs:documentation source="http://dublincore.org/documents/dcmi-terms/#terms-subject"
+                    xml:lang="eng-usa">
+                    <definition>The topic of the resource.</definition>
+                    <comment> Typically, the subject will be represented using keywords, key
+                        phrases, or classification codes. Recommended best practice is to use a
+                        controlled vocabulary. To describe the spatial or temporal topic of the
+                        resource, use the Coverage element. </comment>
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleContent>
+                <xs:extension base="eas:basic-stringtype"> </xs:extension>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="description">
+        <xs:complexType>
+            <xs:annotation>
+                <xs:documentation
+                    source="http://dublincore.org/documents/dcmi-terms/#terms-description"
+                    xml:lang="eng-usa">
+                    <definition>An account of the resource.</definition>
+                    <comment> Description may include but is not limited to: an abstract, a table of
+                        contents, a graphical representation, or a free-text account of the
+                        resource. </comment>
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleContent>
+                <xs:extension base="eas:basic-stringtype"> </xs:extension>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="publisher">
+        <xs:complexType>
+            <xs:annotation>
+                <xs:documentation
+                    source="http://dublincore.org/documents/dcmi-terms/#terms-publisher"
+                    xml:lang="eng-usa">
+                    <definition>An entity responsible for making the resource available.</definition>
+                    <comment> Examples of a Publisher include a person, an organization, or a
+                        service. Typically, the name of a Publisher should be used to indicate the
+                        entity. </comment>
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleContent>
+                <xs:extension base="eas:basic-stringtype"> </xs:extension>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="contributor">
+        <xs:complexType>
+            <xs:annotation>
+                <xs:documentation
+                    source="http://dublincore.org/documents/dcmi-terms/#terms-contributor"
+                    xml:lang="eng-usa">
+                    <definition>An entity responsible for making contributions to the resource.</definition>
+                    <comment> Examples of a Contributor include a person, an organization, or a
+                        service. Typically, the name of a Contributor should be used to indicate the
+                        entity. </comment>
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleContent>
+                <xs:extension base="eas:basic-stringtype"> </xs:extension>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="date">
+        <xs:complexType>
+            <xs:annotation>
+                <xs:documentation source="http://dublincore.org/documents/dcmi-terms/#terms-date"
+                    xml:lang="eng-usa">
+                    <definition>A point or period of time associated with an event in the lifecycle
+                        of the resource.</definition>
+                    <comment> Date may be used to express temporal information at any level of
+                        granularity. Recommended best practice is to use an encoding scheme, such as
+                        the W3CDTF profile of ISO 8601 [W3CDTF]. </comment>
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleContent>
+                <xs:extension base="eas:basic-datetype"/>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="type">
+        <xs:complexType>
+            <xs:annotation>
+                <xs:documentation source="http://dublincore.org/documents/dcmi-terms/#terms-type"
+                    xml:lang="eng-usa">
+                    <definition>The nature or genre of the resource.</definition>
+                    <comment> Recommended best practice is to use a controlled vocabulary such as
+                        the DCMI Type Vocabulary [DCMITYPE]. To describe the file format, physical
+                        medium, or dimensions of the resource, use the Format element. </comment>
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleContent>
+                <xs:extension base="eas:basic-stringtype"> </xs:extension>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="format">
+        <xs:complexType>
+            <xs:annotation>
+                <xs:documentation source="http://dublincore.org/documents/dcmi-terms/#terms-format"
+                    xml:lang="eng-usa">
+                    <definition>The file format, physical medium, or dimensions of the resource.</definition>
+                    <comment> Examples of dimensions include size and duration. Recommended best
+                        practice is to use a controlled vocabulary such as the list of Internet
+                        Media Types [MIME]. </comment>
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleContent>
+                <xs:extension base="eas:basic-stringtype"> </xs:extension>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="identifier">
+        <xs:complexType>
+            <xs:annotation>
+                <xs:documentation
+                    source="http://dublincore.org/documents/dcmi-terms/#terms-identifier"
+                    xml:lang="eng-usa">
+                    <definition>An unambiguous reference to the resource within a given context.</definition>
+                    <comment> Recommended best practice is to identify the resource by means of a
+                        string conforming to a formal identification system. </comment>
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleContent>
+                <xs:extension base="eas:basic-identifiertype">
+                </xs:extension>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="source">
+        <xs:complexType>
+            <xs:annotation>
+                <xs:documentation source="http://dublincore.org/documents/dcmi-terms/#terms-source"
+                    xml:lang="eng-usa">
+                    <definition>A related resource from which the described resource is derived.</definition>
+                    <comment> The described resource may be derived from the related resource in
+                        whole or in part. Recommended best practice is to identify the related
+                        resource by means of a string conforming to a formal identification system.
+                    </comment>
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleContent>
+                <xs:extension base="eas:basic-stringtype">
+                    <xs:attribute ref="eas:identification-system"/>
+                </xs:extension>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="language">
+        <xs:complexType>
+            <xs:annotation>
+                <xs:documentation
+                    source="http://dublincore.org/documents/dcmi-terms/#terms-language"
+                    xml:lang="eng-usa">
+                    <definition>A language of the resource.</definition>
+                    <comment> Recommended best practice is to use a controlled vocabulary such as
+                        RFC 4646 [RFC4646]. </comment>
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleContent>
+                <xs:extension base="eas:basic-stringtype"> </xs:extension>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="relation">
+        <xs:complexType>
+            <xs:annotation>
+                <xs:documentation
+                    source="http://dublincore.org/documents/dcmi-terms/#terms-relation"
+                    xml:lang="eng-usa">
+                    <definition>A related resource.</definition>
+                    <comment> Recommended best practice is to identify the related resource by means
+                        of a string conforming to a formal identification system. </comment>
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleContent>
+                <xs:extension base="eas:basic-identifiertype"/>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="coverage">
+        <xs:complexType>
+            <xs:annotation>
+                <xs:documentation
+                    source="http://dublincore.org/documents/dcmi-terms/#terms-coverage"
+                    xml:lang="eng-usa">
+                    <definition> The spatial or temporal topic of the resource, the spatial
+                        applicability of the resource, or the jurisdiction under which the resource
+                        is relevant. </definition>
+                    <comment> Spatial topic and spatial applicability may be a named place or a
+                        location specified by its geographic coordinates. Temporal topic may be a
+                        named period, date, or date range. A jurisdiction may be a named
+                        administrative entity or a geographic place to which the resource applies.
+                        Recommended best practice is to use a controlled vocabulary such as the
+                        Thesaurus of Geographic Names [TGN]. Where appropriate, named places or time
+                        periods can be used in preference to numeric identifiers such as sets of
+                        coordinates or date ranges. </comment>
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleContent>
+                <xs:extension base="eas:basic-stringtype"> </xs:extension>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="rights">
+        <xs:complexType>
+            <xs:annotation>
+                <xs:documentation source="http://dublincore.org/documents/dcmi-terms/#terms-rights"
+                    xml:lang="eng-usa">
+                    <definition>Information about rights held in and over the resource.</definition>
+                    <comment> Typically, rights information includes a statement about various
+                        property rights associated with the resource, including intellectual
+                        property rights. </comment>
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleContent>
+                <xs:extension base="eas:basic-stringtype"> </xs:extension>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:element>
+
+</xs:schema>

--- a/src/main/assembly/dist/md/emd/xml.xsd
+++ b/src/main/assembly/dist/md/emd/xml.xsd
@@ -1,0 +1,168 @@
+<?xml version='1.0'?>
+<!--
+
+    Copyright (C) 2015-2016 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<xs:schema targetNamespace="http://www.w3.org/XML/1998/namespace" xmlns:xs="http://www.w3.org/2001/XMLSchema" xml:lang="en">
+    
+    <xs:annotation>
+        <xs:documentation>
+            See http://www.w3.org/XML/1998/namespace.html and
+            http://www.w3.org/TR/REC-xml for information about this namespace.
+            
+            This schema document describes the XML namespace, in a form
+            suitable for import by other schema documents.  
+            
+            Note that local names in this namespace are intended to be defined
+            only by the World Wide Web Consortium or its subgroups.  The
+            following names are currently defined in this namespace and should
+            not be used with conflicting semantics by any Working Group,
+            specification, or document instance:
+            
+            base (as an attribute name): denotes an attribute whose value
+            provides a URI to be used as the base for interpreting any
+            relative URIs in the scope of the element on which it
+            appears; its value is inherited.  This name is reserved
+            by virtue of its definition in the XML Base specification.
+            
+            id   (as an attribute name): denotes an attribute whose value
+            should be interpreted as if declared to be of type ID.
+            This name is reserved by virtue of its definition in the
+            xml:id specification.
+            
+            lang (as an attribute name): denotes an attribute whose value
+            is a language code for the natural language of the content of
+            any element; its value is inherited.  This name is reserved
+            by virtue of its definition in the XML specification.
+            
+            space (as an attribute name): denotes an attribute whose
+            value is a keyword indicating what whitespace processing
+            discipline is intended for the content of the element; its
+            value is inherited.  This name is reserved by virtue of its
+            definition in the XML specification.
+            
+            Father (in any context at all): denotes Jon Bosak, the chair of 
+            the original XML Working Group.  This name is reserved by 
+            the following decision of the W3C XML Plenary and 
+            XML Coordination groups:
+            
+            In appreciation for his vision, leadership and dedication
+            the W3C XML Plenary on this 10th day of February, 2000
+            reserves for Jon Bosak in perpetuity the XML name
+            xml:Father
+        </xs:documentation>
+    </xs:annotation>
+    
+    <xs:annotation>
+        <xs:documentation>This schema defines attributes and an attribute group
+            suitable for use by
+            schemas wishing to allow xml:base, xml:lang, xml:space or xml:id
+            attributes on elements they define.
+            
+            To enable this, such a schema must import this schema
+            for the XML namespace, e.g. as follows:
+            &lt;schema . . .>
+            . . .
+            &lt;import namespace="http://www.w3.org/XML/1998/namespace"
+            schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+            
+            Subsequently, qualified reference to any of the attributes
+            or the group defined below will have the desired effect, e.g.
+            
+            &lt;type . . .>
+            . . .
+            &lt;attributeGroup ref="xml:specialAttrs"/>
+            
+            will define a type which will schema-validate an instance
+            element with any of those attributes</xs:documentation>
+        
+    </xs:annotation>
+    
+    <xs:annotation>
+        <xs:documentation>In keeping with the XML Schema WG's standard versioning
+            policy, this schema document will persist at
+            http://www.w3.org/2007/08/xml.xsd.
+            At the date of issue it can also be found at
+            http://www.w3.org/2001/xml.xsd.
+            The schema document at that URI may however change in the future,
+            in order to remain compatible with the latest version of XML Schema
+            itself, or with the XML namespace itself.  In other words, if the XML
+            Schema or XML namespaces change, the version of this document at
+            http://www.w3.org/2001/xml.xsd will change
+            accordingly; the version at
+            http://www.w3.org/2007/08/xml.xsd will not change.
+        </xs:documentation>
+    </xs:annotation>
+    
+    <xs:attribute name="lang">
+        <xs:annotation>
+            <xs:documentation>Attempting to install the relevant ISO 2- and 3-letter
+                codes as the enumerated possible values is probably never
+                going to be a realistic possibility.  See
+                RFC 3066 at http://www.ietf.org/rfc/rfc3066.txt and the IANA registry
+                at http://www.iana.org/assignments/lang-tag-apps.htm for
+                further information.
+                
+                The union allows for the 'un-declaration' of xml:lang with
+                the empty string.</xs:documentation>
+            
+        </xs:annotation>
+        <xs:simpleType>
+            <xs:union memberTypes="xs:language">
+                <xs:simpleType>    
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value=""/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:union>
+            
+        </xs:simpleType>
+    </xs:attribute>
+    
+    <xs:attribute name="space">
+        <xs:simpleType>
+            <xs:restriction base="xs:NCName">
+                <xs:enumeration value="default"/>
+                <xs:enumeration value="preserve"/>
+            </xs:restriction>
+            
+        </xs:simpleType>
+    </xs:attribute>
+    
+    <xs:attribute name="base" type="xs:anyURI">
+        <xs:annotation>
+            <xs:documentation>See http://www.w3.org/TR/xmlbase/ for
+                information about this attribute.</xs:documentation>
+        </xs:annotation>
+    </xs:attribute>
+    
+    <xs:attribute name="id" type="xs:ID">
+        
+        <xs:annotation>
+            <xs:documentation>See http://www.w3.org/TR/xml-id/ for
+                information about this attribute.</xs:documentation>
+        </xs:annotation>
+    </xs:attribute>
+    
+    <xs:attributeGroup name="specialAttrs">
+        <xs:attribute ref="xml:base"/>
+        <xs:attribute ref="xml:lang"/>
+        <xs:attribute ref="xml:space"/>
+        
+        <xs:attribute ref="xml:id"/>
+    </xs:attributeGroup>
+    
+</xs:schema>


### PR DESCRIPTION
no JIRA ISSUE

#### When applied it will
* Place the EMD xsd's in the top directory. The latest version of the xsd will reside both here, and in the appropriate child directory.

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?
Please refer to the latest version of an xsd schema using the URL _without_ the year-version path by default. only when there is a need to refer to an older version should you use the URL with the year-version path

Please note: this pattern will be used for the other schema-dirs as well. (as is already the case for the property-list/audience.xsd)