### PR TITLE
EASY-1238: fix some validation errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <name>EASY Schema Definitions</name>
     <description>Collection of metadata schema's used by EASY</description>
     <version>1.x-SNAPSHOT</version>
-    <inceptionYear>2015</inceptionYear>
+    <inceptionYear>2012</inceptionYear>
     <scm>
         <developerConnection>scm:git:https://github.com/DANS-KNAW/${project.artifactId}</developerConnection>
         <tag>HEAD</tag>
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>nl.knaw.dans.easy</groupId>
             <artifactId>ddm</artifactId>
-            <version>2.16</version>
+            <version>3.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2015 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+    Copyright (C) 2012 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/main/assembly/bin.xml
+++ b/src/main/assembly/bin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
 
-    Copyright (C) 2015 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+    Copyright (C) 2012 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/src/main/assembly/dist/md/2017/ddm.xsd
+++ b/src/main/assembly/dist/md/2017/ddm.xsd
@@ -211,7 +211,7 @@
             <xs:element ref="dc:description" maxOccurs="unbounded"/>
             <xs:element ref="dc:creator" maxOccurs="unbounded"/>
             <xs:element ref="ddm:created"/>
-            <xs:element ref="ddm:available" minOccurs="0"/>
+            <xs:element ref="ddm:available"/>
             <xs:element ref="ddm:audience" maxOccurs="unbounded"/>
             <xs:element ref="ddm:accessRights"/>
         </xs:sequence>

--- a/src/main/assembly/dist/md/2017/ddm.xsd
+++ b/src/main/assembly/dist/md/2017/ddm.xsd
@@ -54,6 +54,8 @@
         schemaLocation="http://easy.dans.knaw.nl/schemas/vocab/2015/narcis-type.xsd"/>
     <xs:import namespace="http://www.den.nl/standaard/166/Archeologisch-Basisregister/"
         schemaLocation="https://easy.dans.knaw.nl/schemas/vocab/2012/abr-type.xsd"/>
+    <xs:import namespace="http://easy.dans.knaw.nl/schemas/dcx/gml/"
+        schemaLocation="https://easy.dans.knaw.nl/schemas/dcx/2016/dcx-gml.xsd"/>
     
     <!-- =================================================================================== -->
     <xs:element name="DDM">

--- a/src/main/assembly/dist/md/2017/ddm.xsd
+++ b/src/main/assembly/dist/md/2017/ddm.xsd
@@ -52,6 +52,8 @@
         schemaLocation="http://easy.dans.knaw.nl/schemas/dcx/2012/10/dcx-dai.xsd"/>
     <xs:import namespace="http://easy.dans.knaw.nl/schemas/vocab/narcis-type/"
         schemaLocation="http://easy.dans.knaw.nl/schemas/vocab/2015/narcis-type.xsd"/>
+    <xs:import namespace="http://www.den.nl/standaard/166/Archeologisch-Basisregister/"
+        schemaLocation="https://easy.dans.knaw.nl/schemas/vocab/2012/abr-type.xsd"/>
     
     <!-- =================================================================================== -->
     <xs:element name="DDM">
@@ -210,7 +212,6 @@
             <xs:element ref="ddm:available" minOccurs="0"/>
             <xs:element ref="ddm:audience" maxOccurs="unbounded"/>
             <xs:element ref="ddm:accessRights"/>
-            <xs:element ref="ddm:relation" minOccurs="0"/>
         </xs:sequence>
     </xs:complexType>
     

--- a/src/main/assembly/dist/md/ddm/ddm.xsd
+++ b/src/main/assembly/dist/md/ddm/ddm.xsd
@@ -211,7 +211,7 @@
             <xs:element ref="dc:description" maxOccurs="unbounded"/>
             <xs:element ref="dc:creator" maxOccurs="unbounded"/>
             <xs:element ref="ddm:created"/>
-            <xs:element ref="ddm:available" minOccurs="0"/>
+            <xs:element ref="ddm:available"/>
             <xs:element ref="ddm:audience" maxOccurs="unbounded"/>
             <xs:element ref="ddm:accessRights"/>
         </xs:sequence>

--- a/src/main/assembly/dist/md/ddm/ddm.xsd
+++ b/src/main/assembly/dist/md/ddm/ddm.xsd
@@ -54,6 +54,8 @@
                schemaLocation="http://easy.dans.knaw.nl/schemas/vocab/2015/narcis-type.xsd"/>
     <xs:import namespace="http://www.den.nl/standaard/166/Archeologisch-Basisregister/"
                schemaLocation="https://easy.dans.knaw.nl/schemas/vocab/2012/abr-type.xsd"/>
+    <xs:import namespace="http://easy.dans.knaw.nl/schemas/dcx/gml/"
+               schemaLocation="https://easy.dans.knaw.nl/schemas/dcx/2016/dcx-gml.xsd"/>
 
     <!-- =================================================================================== -->
     <xs:element name="DDM">

--- a/src/main/assembly/dist/md/ddm/ddm.xsd
+++ b/src/main/assembly/dist/md/ddm/ddm.xsd
@@ -17,42 +17,44 @@
 
 -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-    xmlns:ddm="http://easy.dans.knaw.nl/schemas/md/ddm/"
-    xmlns:dc="http://purl.org/dc/elements/1.1/"
-    xmlns:dcterms="http://purl.org/dc/terms/"
-    xmlns:dcx="http://easy.dans.knaw.nl/schemas/dcx/"
-    xmlns:dcx-dai="http://easy.dans.knaw.nl/schemas/dcx/dai/"
-    xmlns:narcis="http://easy.dans.knaw.nl/schemas/vocab/narcis-type/"
-    targetNamespace="http://easy.dans.knaw.nl/schemas/md/ddm/"
-    elementFormDefault="qualified" attributeFormDefault="unqualified">
-    
+           xmlns:ddm="http://easy.dans.knaw.nl/schemas/md/ddm/"
+           xmlns:dc="http://purl.org/dc/elements/1.1/"
+           xmlns:dcterms="http://purl.org/dc/terms/"
+           xmlns:dcx="http://easy.dans.knaw.nl/schemas/dcx/"
+           xmlns:dcx-dai="http://easy.dans.knaw.nl/schemas/dcx/dai/"
+           xmlns:narcis="http://easy.dans.knaw.nl/schemas/vocab/narcis-type/"
+           targetNamespace="http://easy.dans.knaw.nl/schemas/md/ddm/"
+           elementFormDefault="qualified" attributeFormDefault="unqualified">
+
     <!-- =================================================================================== -->
     <xs:annotation>
         <xs:documentation xml:lang="en">DANS Dataset Metadata (DDM)
-            
-            This schema specifies a metadata-format for describing datasets. 
+
+            This schema specifies a metadata-format for describing datasets.
             An instance of this metadata-format can be used for ingest of datasets with the Sword protocol.
-            
+
             Created 2017-03-28
-            
-            Copyright (c) 2012 DANS-KNAW 
+
+            Copyright (c) 2012 DANS-KNAW
         </xs:documentation>
     </xs:annotation>
-    
+
     <!-- =================================================================================== -->
     <xs:import namespace="http://www.w3.org/XML/1998/namespace"
-        schemaLocation="http://www.w3.org/2001/03/xml.xsd"/>
+               schemaLocation="http://www.w3.org/2001/03/xml.xsd"/>
     <xs:import namespace="http://purl.org/dc/elements/1.1/"
-        schemaLocation="http://dublincore.org/schemas/xmls/qdc/dc.xsd"/>
+               schemaLocation="http://dublincore.org/schemas/xmls/qdc/dc.xsd"/>
     <xs:import namespace="http://purl.org/dc/terms/"
-        schemaLocation="http://dublincore.org/schemas/xmls/qdc/dcterms.xsd"/>
-    <xs:import namespace="http://easy.dans.knaw.nl/schemas/dcx/" 
-        schemaLocation="http://easy.dans.knaw.nl/schemas/dcx/2012/10/dcx.xsd"/>
-    <xs:import namespace="http://easy.dans.knaw.nl/schemas/dcx/dai/" 
-        schemaLocation="http://easy.dans.knaw.nl/schemas/dcx/2012/10/dcx-dai.xsd"/>
+               schemaLocation="http://dublincore.org/schemas/xmls/qdc/dcterms.xsd"/>
+    <xs:import namespace="http://easy.dans.knaw.nl/schemas/dcx/"
+               schemaLocation="http://easy.dans.knaw.nl/schemas/dcx/2012/10/dcx.xsd"/>
+    <xs:import namespace="http://easy.dans.knaw.nl/schemas/dcx/dai/"
+               schemaLocation="http://easy.dans.knaw.nl/schemas/dcx/2012/10/dcx-dai.xsd"/>
     <xs:import namespace="http://easy.dans.knaw.nl/schemas/vocab/narcis-type/"
-        schemaLocation="http://easy.dans.knaw.nl/schemas/vocab/2015/narcis-type.xsd"/>
-    
+               schemaLocation="http://easy.dans.knaw.nl/schemas/vocab/2015/narcis-type.xsd"/>
+    <xs:import namespace="http://www.den.nl/standaard/166/Archeologisch-Basisregister/"
+               schemaLocation="https://easy.dans.knaw.nl/schemas/vocab/2012/abr-type.xsd"/>
+
     <!-- =================================================================================== -->
     <xs:element name="DDM">
         <xs:annotation>
@@ -75,11 +77,11 @@
                     <xs:annotation>
                         <xs:documentation xml:lang="en">
                             Container for dcmi metadata. (Optional)
-                            
+
                             All elements of the http://purl.org/dc/elements/1.1/ namespace can be used.
                             All elements of the http://purl.org/dc/terms/ namespace can be used.
                             All elements defined in this schema that are extensions or restrictions of dc or dcterms elements can be used.
-                            
+
                             Where applicable the use of the xml:lang attribute is recommended.
                             Where applicable the use of the xsi:type attribute is recommended.
                             See also:
@@ -92,41 +94,41 @@
             </xs:all>
         </xs:complexType>
     </xs:element>
-    
+
     <!-- =================================================================================== -->
     <xs:element name="created" substitutionGroup="dcterms:created" type="dcterms:W3CDTF">
         <xs:annotation>
             <xs:documentation xml:lang="en">
                 Restriction on dcterms:created.
-                
+
                 Element value MUST conform to the dcterms:W3CDTF format.
-                
+
                 See also: http://purl.org/dc/terms/created
             </xs:documentation>
         </xs:annotation>
     </xs:element>
-    
+
     <!-- =================================================================================== -->
     <xs:element name="available" substitutionGroup="dcterms:available" type="dcterms:W3CDTF">
         <xs:annotation>
             <xs:documentation xml:lang="en">
                 Restriction on dcterms:available.
-                
+
                 Element value MUST conform to the dcterms:W3CDTF format.
-                
+
                 See also: http://purl.org/dc/terms/available
             </xs:documentation>
         </xs:annotation>
     </xs:element>
-    
+
     <!-- =================================================================================== -->
     <xs:element name="audience" substitutionGroup="dcterms:audience" type="narcis:DisciplineType">
         <xs:annotation>
             <xs:documentation xml:lang="en">
                 Restriction on dcterms:audience.
-                
+
                 Element value MUST conform to the narcis:DisciplineType.
-                
+
                 See also: http://purl.org/dc/terms/audience
             </xs:documentation>
         </xs:annotation>
@@ -137,9 +139,9 @@
         <xs:annotation>
             <xs:documentation xml:lang="en">
                 Restriction on dcterms:accessRights.
-                
+
                 Element value MUST conform to ddm:EasyAccessRightsType.
-                
+
                 See also: http://purl.org/dc/terms/accessRights
             </xs:documentation>
         </xs:annotation>
@@ -194,7 +196,7 @@
             </xs:sequence>
         </xs:complexType>
     </xs:element>
-    
+
     <!-- =================================================================================== -->
     <xs:complexType name="profileType">
         <xs:annotation>
@@ -210,10 +212,9 @@
             <xs:element ref="ddm:available" minOccurs="0"/>
             <xs:element ref="ddm:audience" maxOccurs="unbounded"/>
             <xs:element ref="ddm:accessRights"/>
-            <xs:element ref="ddm:relation" minOccurs="0"/>
         </xs:sequence>
     </xs:complexType>
-    
+
     <!-- =================================================================================== -->
     <xs:complexType name="EasyAccessRightsType">
         <xs:annotation>
@@ -230,7 +231,7 @@
             </xs:restriction>
         </xs:simpleContent>
     </xs:complexType>
-    
+
     <!-- =================================================================================== -->
     <xs:simpleType name="EasyAccessCategoryType">
         <xs:restriction base="xs:NMTOKEN">

--- a/src/test/scala/nl/knaw/dans/easy/schema/DDM2EMDSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/schema/DDM2EMDSpec.scala
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2015 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ * Copyright (C) 2012 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/nl/knaw/dans/easy/schema/PackagingSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/schema/PackagingSpec.scala
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2015 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ * Copyright (C) 2012 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
fixes EASY-1238

#### When applied it will
* Remove the ddm:relation from the ddm:profile
* Make ddm:available date required
* Import the ABR namespace
* Correct the inceptionYear in the pom and update ddm to version 3.0
* Update the license headers
* Import the correct dcx-gml

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 
