### PR TITLE
Add springfield-actions.xsd as an external schema

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,14 +67,15 @@
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin</artifactId>
                 <configuration combine.children="append">
-                    <excludes combine.self="override" />
+                    <excludes combine.self="override">
+                        <exclude>src/main/assembly/dist/extern/*.xsd</exclude>
+                    </excludes>
                     <includes>
                         <include>pom.xml</include>
                         <include>src/test/scala/**</include>
                         <include>src/main/assembly/**/*.xsd</include>
                         <include>src/main/assembly/**/*.xml</include>
                     </includes>
-                    <excludes>src/main/assembly/dist/extern/*.xsd</excludes>
                 </configuration>
             </plugin>
             <!-- Avoid build warning about generating empty jar -->

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
                         <include>src/main/assembly/**/*.xsd</include>
                         <include>src/main/assembly/**/*.xml</include>
                     </includes>
+                    <excludes>src/main/assembly/dist/extern/*.xsd</excludes>
                 </configuration>
             </plugin>
             <!-- Avoid build warning about generating empty jar -->

--- a/src/main/assembly/dist/extern/springfield-actions.xsd
+++ b/src/main/assembly/dist/extern/springfield-actions.xsd
@@ -20,7 +20,11 @@
                 <xs:element ref="sf:presentation"/>
                 <xs:element ref="sf:user"/>
             </xs:choice>
-            <xs:attribute name="target" use="required"/>
+            <xs:attribute name="target" use="required">
+                <xs:annotation>
+                    <xs:documentation>the target MUST NOT end in a slash '/' or subsequent Springfield processes will fail</xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
         </xs:complexType>
     </xs:element>
     <xs:element name="collection">
@@ -55,27 +59,7 @@
                     </xs:restriction>
                 </xs:simpleType>
             </xs:attribute>
-            <xs:assert
-                    test="
-                    every $video in sf:video
-                        satisfies @play-mode = 'continuous' or $video/@title"/>
-            <xs:assert
-                    test="
-                    every $audio in sf:audio
-                        satisfies @play-mode = 'continuous' or $audio/@title"/>
         </xs:complexType>
-        <xs:unique name="UniqueSrc">
-            <xs:selector xpath="*"/>
-            <xs:field xpath="@src"/>
-        </xs:unique>
-        <xs:unique name="UniqueTarget">
-            <xs:selector xpath="*"/>
-            <xs:field xpath="@target"/>
-        </xs:unique>
-        <xs:unique name="UniqueTitle">
-            <xs:selector xpath="*"/>
-            <xs:field xpath="@title"/>
-        </xs:unique>
     </xs:element>
     <xs:element name="video">
         <xs:annotation>
@@ -90,7 +74,6 @@
                     <xs:documentation>relative path to the video file</xs:documentation>
                 </xs:annotation>
             </xs:attribute>
-            <xs:attribute name="subtitles"><xs:annotation><xs:documentation>Deprecated. please use the subtitles-tag instead.</xs:documentation></xs:annotation></xs:attribute>
             <xs:attribute name="target" use="required" type="xs:string">
                 <xs:annotation>
                     <xs:documentation>used to determine the order in which the files will be played, by sorting the target-values alpha-numerically</xs:documentation>
@@ -101,18 +84,7 @@
                     <xs:documentation>human readable title of the video file, used when the presentation is in 'menu' mode</xs:documentation>
                 </xs:annotation>
             </xs:attribute>
-            <xs:assert
-                    test="
-                    if (exists(@subtitles)) then
-                        (count(sf:subtitles)) = 0
-                    else
-                        true()"
-            />
         </xs:complexType>
-        <xs:unique name="UniqueSubtitlesLanguage">
-            <xs:selector xpath="sf:subtitles"/>
-            <xs:field xpath="@xml:lang"/>
-        </xs:unique>
     </xs:element>
     <xs:element name="audio">
         <xs:annotation>
@@ -137,6 +109,9 @@
         </xs:complexType>
     </xs:element>
     <xs:element name="subtitles">
+        <xs:annotation>
+            <xs:documentation>in one video-playlist, all video's SHOULD have the same number of subtitles, with the same languages</xs:documentation>
+        </xs:annotation>
         <xs:complexType>
             <xs:attribute name="src" use="required"/>
             <xs:attribute ref="xml:lang" use="required"/>
@@ -144,7 +119,7 @@
     </xs:element>
     <xs:element name="user">
         <xs:complexType>
-            <xs:attribute name="name" use="required" type="xs:NCName"/>
+            <xs:attribute name="name" use="required" type="xs:string"/>
         </xs:complexType>
     </xs:element>
 </xs:schema>

--- a/src/main/assembly/dist/extern/springfield-actions.xsd
+++ b/src/main/assembly/dist/extern/springfield-actions.xsd
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:sf="springfield-actions" xmlns:xml="http://www.w3.org/XML/1998/namespace"
+           targetNamespace="springfield-actions" xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+    <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/03/xml.xsd"/>
+    <xs:annotation>
+        <xs:documentation>2017-08: @play-mode attribuut toegevoegd in de video-playlist met twee mogelijke
+            waarden, continuous en menu. voor elke video/audio in menu-playlist moet een @title attribuut aanwezig zijn. </xs:documentation>
+    </xs:annotation>
+    <xs:element name="actions">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element maxOccurs="unbounded" ref="sf:add"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="add">
+        <xs:complexType>
+            <xs:choice>
+                <xs:element ref="sf:collection"/>
+                <xs:element ref="sf:presentation"/>
+                <xs:element ref="sf:user"/>
+            </xs:choice>
+            <xs:attribute name="target" use="required"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="collection">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="title" type="xs:string"/>
+                <xs:element name="description" type="xs:string"/>
+            </xs:sequence>
+            <xs:attribute name="name" use="required" type="xs:NCName"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="presentation">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="sf:video-playlist"/>
+            </xs:sequence>
+            <xs:attribute name="name" use="required" type="xs:string"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="video-playlist">
+        <xs:complexType>
+            <xs:choice>
+                <xs:element maxOccurs="unbounded" minOccurs="0" ref="sf:video"/>
+                <xs:element maxOccurs="unbounded" minOccurs="0" ref="sf:audio"/>
+            </xs:choice>
+            <xs:attribute name="require-ticket" type="xs:boolean" default="true"/>
+            <xs:attribute name="play-mode" default="continuous" use="optional">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="continuous"/>
+                        <xs:enumeration value="menu"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:attribute>
+            <xs:assert
+                    test="
+                    every $video in sf:video
+                        satisfies @play-mode = 'continuous' or $video/@title"/>
+            <xs:assert
+                    test="
+                    every $audio in sf:audio
+                        satisfies @play-mode = 'continuous' or $audio/@title"/>
+        </xs:complexType>
+        <xs:unique name="UniqueSrc">
+            <xs:selector xpath="*"/>
+            <xs:field xpath="@src"/>
+        </xs:unique>
+        <xs:unique name="UniqueTarget">
+            <xs:selector xpath="*"/>
+            <xs:field xpath="@target"/>
+        </xs:unique>
+        <xs:unique name="UniqueTitle">
+            <xs:selector xpath="*"/>
+            <xs:field xpath="@title"/>
+        </xs:unique>
+    </xs:element>
+    <xs:element name="video">
+        <xs:annotation>
+            <xs:documentation>container of one video file</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element minOccurs="0" maxOccurs="unbounded" ref="sf:subtitles"/>
+            </xs:sequence>
+            <xs:attribute name="src" use="required">
+                <xs:annotation>
+                    <xs:documentation>relative path to the video file</xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="subtitles"><xs:annotation><xs:documentation>Deprecated. please use the subtitles-tag instead.</xs:documentation></xs:annotation></xs:attribute>
+            <xs:attribute name="target" use="required" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation>used to determine the order in which the files will be played, by sorting the target-values alpha-numerically</xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="title">
+                <xs:annotation>
+                    <xs:documentation>human readable title of the video file, used when the presentation is in 'menu' mode</xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:assert
+                    test="
+                    if (exists(@subtitles)) then
+                        (count(sf:subtitles)) = 0
+                    else
+                        true()"
+            />
+        </xs:complexType>
+        <xs:unique name="UniqueSubtitlesLanguage">
+            <xs:selector xpath="sf:subtitles"/>
+            <xs:field xpath="@xml:lang"/>
+        </xs:unique>
+    </xs:element>
+    <xs:element name="audio">
+        <xs:annotation>
+            <xs:documentation>container of one audio file</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:attribute name="src" use="required">
+                <xs:annotation>
+                    <xs:documentation>relative path to the audio file</xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="target" use="required" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation>used to determine the order in which the files will be played, by sorting the target-values alpha-numerically</xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="title">
+                <xs:annotation>
+                    <xs:documentation>human readable title of the audio file, used when the presentation is in 'menu' mode</xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="subtitles">
+        <xs:complexType>
+            <xs:attribute name="src" use="required"/>
+            <xs:attribute ref="xml:lang" use="required"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="user">
+        <xs:complexType>
+            <xs:attribute name="name" use="required" type="xs:NCName"/>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>


### PR DESCRIPTION
NO-EASY

#### When applied it will
* Add the springfield schema as an external schema
* Remove the xml-schema-1.1 specific stuff from springfield-actions
* Exclude external schemas from getting a DANS license header

#### Where should the reviewer @DANS-KNAW/easy start?
