### PR TITLE
Fix rpm user/group

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>nl.knaw.dans.easy</groupId>
     <artifactId>easy-schema</artifactId>
-    <version>1.13.2-beta-1</version>
+    <version>1.13.2-SNAPSHOT</version>
 
     <name>EASY Schema Definitions</name>
     <description>Collection of metadata schema's used by EASY</description>
@@ -35,7 +35,7 @@
 
     <scm>
         <developerConnection>scm:git:https://github.com/DANS-KNAW/${project.artifactId}</developerConnection>
-        <tag>v1.13.2-beta-1</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>nl.knaw.dans.easy</groupId>
     <artifactId>easy-schema</artifactId>
-    <version>1.13.2-SNAPSHOT</version>
+    <version>1.13.2-beta-1</version>
 
     <name>EASY Schema Definitions</name>
     <description>Collection of metadata schema's used by EASY</description>
@@ -35,7 +35,7 @@
 
     <scm>
         <developerConnection>scm:git:https://github.com/DANS-KNAW/${project.artifactId}</developerConnection>
-        <tag>HEAD</tag>
+        <tag>v1.13.2-beta-1</tag>
     </scm>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,8 @@
                             </execution>
                         </executions>
                         <configuration>
+                            <defaultUsername>root</defaultUsername>
+                            <defaultGroupname>root</defaultGroupname>
                             <group>Applications/Archiving</group>
                             <mappings combine.self="override">
                                 <mapping>


### PR DESCRIPTION
The RPM tried to set the owner and group of all the files to `easy-schema`. This led to a warning, as this user and group do not exist. This behaviour was inherited from `dans-parent` and does make sense for services, that have their own sysem user. Fixed the problem by overriding the rpm config to set the user/group to root/root.