### PR TITLE
XML 1.1 to 1.0

### DIFF
--- a/src/main/assembly/dist/bag/metadata/files/2017/09/files.xsd
+++ b/src/main/assembly/dist/bag/metadata/files/2017/09/files.xsd
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     Copyright (C) 2012 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
@@ -47,9 +47,6 @@
                     </xs:annotation>
                 </xs:element>
             </xs:all>
-            <xs:assert test="
-                    every $fi in f:file
-                        satisfies $fi/dcterms:format"/>
         </xs:complexType>
     </xs:element>
 

--- a/src/main/assembly/dist/bag/metadata/files/2017/09/files.xsd
+++ b/src/main/assembly/dist/bag/metadata/files/2017/09/files.xsd
@@ -40,13 +40,16 @@
     <!-- =================================================================================== -->
     <xs:element name="files">
         <xs:complexType>
-            <xs:all>
+            <xs:sequence>
                 <xs:element name="file" type="f:dcterms-elements" maxOccurs="unbounded">
                     <xs:annotation>
-                        <xs:documentation xml:lang="en">Container for file-specific information with qualified dcterms elements.</xs:documentation>
+                        <xs:documentation xml:lang="en">
+                            Container for file-specific information with qualified dcterms elements.
+                            Every file MUST specify at least a dcterms:format element.
+                        </xs:documentation>
                     </xs:annotation>
                 </xs:element>
-            </xs:all>
+            </xs:sequence>
         </xs:complexType>
     </xs:element>
 

--- a/src/main/assembly/dist/bag/metadata/files/files.xsd
+++ b/src/main/assembly/dist/bag/metadata/files/files.xsd
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     Copyright (C) 2012 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
@@ -47,9 +47,6 @@
                     </xs:annotation>
                 </xs:element>
             </xs:all>
-            <xs:assert test="
-                    every $fi in f:file
-                        satisfies $fi/dcterms:format"/>
         </xs:complexType>
     </xs:element>
 

--- a/src/main/assembly/dist/bag/metadata/files/files.xsd
+++ b/src/main/assembly/dist/bag/metadata/files/files.xsd
@@ -40,13 +40,16 @@
     <!-- =================================================================================== -->
     <xs:element name="files">
         <xs:complexType>
-            <xs:all>
+            <xs:sequence>
                 <xs:element name="file" type="f:dcterms-elements" maxOccurs="unbounded">
                     <xs:annotation>
-                        <xs:documentation xml:lang="en">Container for file-specific information with qualified dcterms elements.</xs:documentation>
+                        <xs:documentation xml:lang="en">
+                            Container for file-specific information with qualified dcterms elements.
+                            Every file MUST specify at least a dcterms:format element.
+                        </xs:documentation>
                     </xs:annotation>
                 </xs:element>
-            </xs:all>
+            </xs:sequence>
         </xs:complexType>
     </xs:element>
 


### PR DESCRIPTION
@DANS-KNAW/easy for review

XML 1.1 validation doesn't work in easy-ingest-flow, so we revert this back to a 1.0 scheme