### PR TITLE
EASY-1356: make relations non-empty tags in ddm

### DIFF
--- a/src/main/assembly/dist/docs/examples/ddm/example1.xml
+++ b/src/main/assembly/dist/docs/examples/ddm/example1.xml
@@ -21,7 +21,7 @@
     xmlns:dc="http://purl.org/dc/elements/1.1/"
     xmlns:dct="http://purl.org/dc/terms/"
     xmlns:dcx-dai="http://easy.dans.knaw.nl/schemas/dcx/dai/"
-    xsi:schemaLocation="http://easy.dans.knaw.nl/schemas/md/ddm/ http://easy.dans.knaw.nl/schemas/md/2017/08/ddm.xsd">
+    xsi:schemaLocation="http://easy.dans.knaw.nl/schemas/md/ddm/ http://easy.dans.knaw.nl/schemas/md/2017/09/ddm.xsd">
     
     <!-- If you view this example in a browser, click 'page source' to see the namespace declarations. -->
     

--- a/src/main/assembly/dist/docs/examples/ddm/example2.xml
+++ b/src/main/assembly/dist/docs/examples/ddm/example2.xml
@@ -31,8 +31,8 @@
 		 xsi:schemaLocation="
 		 http://easy.dans.knaw.nl/schemas/dcx/ http://easy.dans.knaw.nl/schemas/dcx/2012/10/dcx.xsd
 		 http://easy.dans.knaw.nl/schemas/dcx/dai/ http://easy.dans.knaw.nl/schemas/dcx/2012/10/dcx-dai.xsd
-		 http://easy.dans.knaw.nl/schemas/dcx/gml/ http://easy.dans.knaw.nl/schemas/dcx/2017/dcx-gml.xsd
-		 http://easy.dans.knaw.nl/schemas/md/ddm/ http://easy.dans.knaw.nl/schemas/md/2017/08/ddm.xsd
+		 http://easy.dans.knaw.nl/schemas/dcx/gml/ http://easy.dans.knaw.nl/schemas/dcx/2016/dcx-gml.xsd
+		 http://easy.dans.knaw.nl/schemas/md/ddm/ http://easy.dans.knaw.nl/schemas/md/2017/09/ddm.xsd
 		 http://easy.dans.knaw.nl/schemas/vocab/narcis-type/ http://easy.dans.knaw.nl/schemas/vocab/2015/narcis-type.xsd
 		 http://www.den.nl/standaard/166/Archeologisch-Basisregister/ http://easy.dans.knaw.nl/schemas/vocab/2012/10/abr-type.xsd
 

--- a/src/main/assembly/dist/md/2017/09/ddm.xsd
+++ b/src/main/assembly/dist/md/2017/09/ddm.xsd
@@ -1,0 +1,362 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2012 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:ddm="http://easy.dans.knaw.nl/schemas/md/ddm/"
+           xmlns:dc="http://purl.org/dc/elements/1.1/"
+           xmlns:dcterms="http://purl.org/dc/terms/"
+           xmlns:dcx="http://easy.dans.knaw.nl/schemas/dcx/"
+           xmlns:dcx-dai="http://easy.dans.knaw.nl/schemas/dcx/dai/"
+           xmlns:narcis="http://easy.dans.knaw.nl/schemas/vocab/narcis-type/"
+           xmlns:id-type="http://easy.dans.knaw.nl/schemas/vocab/identifier-type/"
+           targetNamespace="http://easy.dans.knaw.nl/schemas/md/ddm/"
+           elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+    <!-- =================================================================================== -->
+    <xs:annotation>
+        <xs:documentation xml:lang="en">DANS Dataset Metadata (DDM)
+
+            This schema specifies a metadata-format for describing datasets.
+            An instance of this metadata-format can be used for ingest of datasets with the Sword protocol.
+
+            Created 2017-03-28
+
+            Copyright (c) 2012 DANS-KNAW
+        </xs:documentation>
+    </xs:annotation>
+
+    <!-- =================================================================================== -->
+    <xs:import namespace="http://www.w3.org/XML/1998/namespace"
+               schemaLocation="http://www.w3.org/2001/03/xml.xsd"/>
+    <!-- this schema location is temporary, since the original (http://dublincore.org/schemas/xmls/qdc/dc.xsd) is not available -->
+    <xs:import namespace="http://purl.org/dc/elements/1.1/"
+               schemaLocation="http://dublincore.org/schemas/xmls/qdc/2008/02/11/dc.xsd"/>
+    <!-- this schema location is temporary, since the original (http://dublincore.org/schemas/xmls/qdc/dcterms.xsd) is not available -->
+    <xs:import namespace="http://purl.org/dc/terms/"
+               schemaLocation="http://dublincore.org/schemas/xmls/qdc/2008/02/11/dcterms.xsd"/>
+    <xs:import namespace="http://easy.dans.knaw.nl/schemas/dcx/"
+               schemaLocation="http://easy.dans.knaw.nl/schemas/dcx/2012/10/dcx.xsd"/>
+    <xs:import namespace="http://easy.dans.knaw.nl/schemas/dcx/dai/"
+               schemaLocation="http://easy.dans.knaw.nl/schemas/dcx/2012/10/dcx-dai.xsd"/>
+    <xs:import namespace="http://easy.dans.knaw.nl/schemas/vocab/narcis-type/"
+               schemaLocation="http://easy.dans.knaw.nl/schemas/vocab/2015/narcis-type.xsd"/>
+    <xs:import namespace="http://easy.dans.knaw.nl/schemas/vocab/identifier-type/"
+               schemaLocation="http://easy.dans.knaw.nl/schemas/vocab/2017/identifier-type.xsd"/>
+    <xs:import namespace="http://www.den.nl/standaard/166/Archeologisch-Basisregister/"
+               schemaLocation="http://easy.dans.knaw.nl/schemas/vocab/2012/abr-type.xsd"/>
+    <xs:import namespace="http://easy.dans.knaw.nl/schemas/dcx/gml/"
+               schemaLocation="http://easy.dans.knaw.nl/schemas/dcx/2016/dcx-gml.xsd"/>
+
+    <!-- =================================================================================== -->
+    <xs:element name="DDM">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                Root element of DANS Dataset Metadata. DDM-instances MUST have one ddm:profile element and MAY have
+                one ddm:dcmiMetadata element and one ddm:additional-xml element.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:all>
+                <xs:element name="profile" type="ddm:profileType">
+                    <xs:annotation>
+                        <xs:documentation xml:lang="en">
+                            Container for Easy-specific information. (Required)
+                            The information in this group is essential for profiling the dataset in the Easy application.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="dcmiMetadata" type="dcterms:elementOrRefinementContainer" minOccurs="0">
+                    <xs:annotation>
+                        <xs:documentation xml:lang="en">
+                            Container for dcmi metadata. (Optional)
+
+                            All elements of the http://purl.org/dc/elements/1.1/ namespace can be used.
+                            All elements of the http://purl.org/dc/terms/ namespace can be used.
+                            All elements defined in this schema that are extensions or restrictions of dc or dcterms elements can be used.
+
+                            Where applicable the use of the xml:lang attribute is recommended.
+                            Where applicable the use of the xsi:type attribute is recommended.
+                            See also:
+                            http://dublincore.org/documents/dcmi-terms/
+                            http://dublincore.org/schemas/xmls/qdc/dcterms.xsd
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element ref="ddm:additional-xml" minOccurs="0"/>
+            </xs:all>
+        </xs:complexType>
+    </xs:element>
+
+    <!-- =================================================================================== -->
+    <xs:element name="created" substitutionGroup="dcterms:created" type="dcterms:W3CDTF">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                Restriction on dcterms:created.
+
+                Element value MUST conform to the dcterms:W3CDTF format.
+
+                See also: http://purl.org/dc/terms/created
+            </xs:documentation>
+        </xs:annotation>
+    </xs:element>
+
+    <!-- =================================================================================== -->
+    <xs:element name="available" substitutionGroup="dcterms:available" type="dcterms:W3CDTF">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                Restriction on dcterms:available.
+
+                Element value MUST conform to the dcterms:W3CDTF format.
+
+                See also: http://purl.org/dc/terms/available
+            </xs:documentation>
+        </xs:annotation>
+    </xs:element>
+
+    <!-- =================================================================================== -->
+    <xs:element name="audience" substitutionGroup="dcterms:audience" type="narcis:DisciplineType">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                Restriction on dcterms:audience.
+
+                Element value MUST conform to the narcis:DisciplineType.
+
+                See also: http://purl.org/dc/terms/audience
+            </xs:documentation>
+        </xs:annotation>
+    </xs:element>
+
+    <!-- =================================================================================== -->
+    <xs:element name="accessRights" substitutionGroup="dcterms:accessRights" type="ddm:EasyAccessRightsType">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                Restriction on dcterms:accessRights.
+
+                Element value MUST conform to ddm:EasyAccessRightsType.
+
+                See also: http://purl.org/dc/terms/accessRights
+            </xs:documentation>
+        </xs:annotation>
+    </xs:element>
+
+    <!-- =================================================================================== -->
+    <xs:element name="relation" substitutionGroup="dc:relation">
+        <xs:annotation>
+            <xs:documentation>
+                This extension on dc:relation can be used in two ways:
+                    1. as a substitutionGroup for ddm:linkedRelation. in that case, use the href-attribute
+                    2. as a substitutionGroup for ddm:DdmRelationType. in that case, use the scheme attribute
+
+                    so either the href or scheme attribute MUST be provided
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="ddm:LinkedRelationType">
+                    <xs:attribute ref="xml:lang" use="prohibited"/>
+                    <xs:attribute name="scheme" type="ddm:RelationTypeSchema"/>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:complexType name="DdmRelationType">
+        <xs:complexContent>
+            <xs:extension base="dc:SimpleLiteral">
+                <xs:attribute ref="xml:lang" use="prohibited"/>
+                <xs:attribute name="scheme" use="required" type="ddm:RelationTypeSchema"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:simpleType name="RelationTypeSchema">
+        <xs:restriction base="xs:NMTOKEN">
+            <xs:enumeration value="STREAMING_SURROGATE_RELATION">
+                <xs:annotation>
+                    <xs:documentation>
+                        Location on the video streaming service.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:element name="linkedRelation" substitutionGroup="dc:relation" type="ddm:LinkedRelationType">
+        <xs:annotation>
+            <xs:documentation>
+                all dcterms relation types can also extend this linkedRelation,
+                and take a 'href' attribute to include a webresource
+            </xs:documentation>
+        </xs:annotation>
+    </xs:element>
+
+    <xs:complexType name="LinkedRelationType">
+        <xs:complexContent>
+            <xs:extension base="ddm:NonEmptyString"> 
+                <xs:attribute name="href" type="xs:anyURI">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The URI of the relation.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    
+    <xs:complexType name="NonEmptyString">
+        <xs:simpleContent>
+            <xs:restriction base="dc:SimpleLiteral">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:minLength value="1"/>
+                        <xs:pattern value=".*[^\s].*"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:restriction>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:element name="conformsTo" substitutionGroup="ddm:linkedRelation"/>
+    <xs:element name="hasFormat" substitutionGroup="ddm:linkedRelation"/>
+    <xs:element name="hasPart" substitutionGroup="ddm:linkedRelation"/>
+    <xs:element name="hasVersion" substitutionGroup="ddm:linkedRelation"/>
+    <xs:element name="isFormatOf" substitutionGroup="ddm:linkedRelation"/>
+    <xs:element name="isPartOf" substitutionGroup="ddm:linkedRelation"/>
+    <xs:element name="isReferencedBy" substitutionGroup="ddm:linkedRelation"/>
+    <xs:element name="isReplacedBy" substitutionGroup="ddm:linkedRelation"/>
+    <xs:element name="isRequiredBy" substitutionGroup="ddm:linkedRelation"/>
+    <xs:element name="isVersionOf" substitutionGroup="ddm:linkedRelation"/>
+    <xs:element name="references" substitutionGroup="ddm:linkedRelation"/>
+    <xs:element name="replaces" substitutionGroup="ddm:linkedRelation"/>
+    <xs:element name="requires" substitutionGroup="ddm:linkedRelation"/>
+
+    <!-- =================================================================================== -->
+    <xs:element name="additional-xml">
+        <xs:annotation>
+            <xs:documentation>
+                Any valid xml-element will do as a child of this element, as long as its namespace is ##other.
+                If a schemaLocation is provided on the element, validating agents will validate the provided xml against that schema.
+                The element may be complex.
+            </xs:documentation>
+            <xs:documentation xml:lang="en">
+                Some xml-elements from the dc and dcterms namespace have possible values for the xsi:type attribute that will be interpreted during ingest.
+                <p xmlns="http://www.w3.org/1999/xhtml">
+                    <dl>
+                        <dt>dc:identifier</dt>
+                        <dd>can have an xsi:type from the "id-type" namespace. This will be interpreted as described there.</dd>
+                        <dt>dc:language</dt>
+                        <dd>can have xsi-type="dcterms:ISO639-2". It should then be formatted accordingly: <a href="https://www.loc.gov/standards/iso639-2/php/code_list.php">ISO639-2</a>.
+                            Both `B` and `T` variants are supported.
+                        </dd>
+                        <dt>dc:format</dt>
+                        <dd>can have an xsi:type="dcterms:IMT" if the value provided is valid according to that vocabulary</dd>
+                        <dt>dcterms:type</dt>
+                        <dd>can have an xsi:type="dcterms:DCMIType". Only values from the set {`Collection`, `Dataset`, `Event`, `Image`,
+                            `InteractiveResource`, `MovingImage`, `PhysicalObject`, `Service`, `Software`, `Sound`, `StillImage`, `Text`} are
+                            valid.
+                        </dd>
+                    </dl>
+                </p>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:any namespace="##other" processContents="lax" maxOccurs="unbounded"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <!-- =================================================================================== -->
+    <xs:complexType name="profileType">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                Detailed specification of the information that is essential for profiling the dataset in the Easy application.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element ref="dc:title" maxOccurs="unbounded"/>
+            <xs:element ref="dc:description" maxOccurs="unbounded"/>
+            <xs:element ref="dc:creator" maxOccurs="unbounded"/>
+            <xs:element ref="ddm:created"/>
+            <xs:element ref="ddm:available"/>
+            <xs:element ref="ddm:audience" maxOccurs="unbounded"/>
+            <xs:element ref="ddm:accessRights"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <!-- =================================================================================== -->
+    <xs:complexType name="EasyAccessRightsType">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                Use on dcterms:accessRights or members of its substitutionGroup.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:simpleContent>
+            <xs:restriction base="dc:SimpleLiteral">
+                <xs:simpleType>
+                    <xs:restriction base="ddm:EasyAccessCategoryType"/>
+                </xs:simpleType>
+                <xs:attribute ref="xml:lang" use="prohibited"/>
+            </xs:restriction>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <!-- =================================================================================== -->
+    <xs:simpleType name="EasyAccessCategoryType">
+        <xs:restriction base="xs:NMTOKEN">
+            <xs:enumeration value="OPEN_ACCESS">
+                <xs:annotation>
+                    <xs:documentation>
+                        Unrestricted access.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OPEN_ACCESS_FOR_REGISTERED_USERS">
+                <xs:annotation>
+                    <xs:documentation>
+                        Unrestricted access for all registered EASY users.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GROUP_ACCESS">
+                <xs:annotation>
+                    <xs:documentation>
+                        Access restricted to registered members of a group.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="REQUEST_PERMISSION">
+                <xs:annotation>
+                    <xs:documentation>
+                        Registered EASY users, but only after depositor permission is granted.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="NO_ACCESS">
+                <xs:annotation>
+                    <xs:documentation>
+                        The data are not available via Easy (they are either accessible in another way or elsewhere).
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <!-- =================================================================================== -->
+</xs:schema>

--- a/src/main/assembly/dist/md/ddm/ddm.xsd
+++ b/src/main/assembly/dist/md/ddm/ddm.xsd
@@ -207,7 +207,7 @@
 
     <xs:complexType name="LinkedRelationType">
         <xs:complexContent>
-            <xs:extension base="dc:SimpleLiteral">
+            <xs:extension base="ddm:NonEmptyString"> 
                 <xs:attribute name="href" type="xs:anyURI">
                     <xs:annotation>
                         <xs:documentation>
@@ -217,6 +217,19 @@
                 </xs:attribute>
             </xs:extension>
         </xs:complexContent>
+    </xs:complexType>
+    
+    <xs:complexType name="NonEmptyString">
+        <xs:simpleContent>
+            <xs:restriction base="dc:SimpleLiteral">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:minLength value="1"/>
+                        <xs:pattern value=".*[^\s].*"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:restriction>
+        </xs:simpleContent>
     </xs:complexType>
 
     <xs:element name="conformsTo" substitutionGroup="ddm:linkedRelation"/>


### PR DESCRIPTION
fixes EASY-1356

#### When applied it will
* make all relations be non-empty in ddm
* update the ddm-examples accordingly


#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR | notes
------------ | -------------|---
easy-split-multi-deposit                      | [PR#93](https://github.com/DANS-KNAW/easy-split-multi-deposit/pull/93) | although not required, they are related
