### PR TITLE
EASY-1374: ddm:subject in ddm scheme

### DIFF
--- a/src/main/assembly/dist/docs/examples/ddm/example1.xml
+++ b/src/main/assembly/dist/docs/examples/ddm/example1.xml
@@ -113,6 +113,12 @@
         <dc:subject>school leavers</dc:subject>
         <dc:subject>labour market</dc:subject>
 
+        <!-- use of a ddm:subject -->
+        <ddm:subject subjectScheme="Art and Architecture Thesaurus"
+                     schemeURI="http://vocab.getty.edu/aat/"
+                     valueURI="http://vocab.getty.edu/aat/300209303"
+                     xml:lang="en">fibulae</ddm:subject>
+
         <ddm:relation href="http://www.example.com">example.com</ddm:relation>
         <ddm:isPartOf href="http://doi.org/journaldoi">journal title</ddm:isPartOf>
 

--- a/src/main/assembly/dist/md/2017/09/ddm.xsd
+++ b/src/main/assembly/dist/md/2017/09/ddm.xsd
@@ -181,10 +181,10 @@
         <xs:annotation>
             <xs:documentation>
                 This extension on dc:relation can be used in two ways:
-                    1. as a substitutionGroup for ddm:linkedRelation. in that case, use the href-attribute
-                    2. as a substitutionGroup for ddm:DdmRelationType. in that case, use the scheme attribute
+                1. as a substitutionGroup for ddm:linkedRelation. in that case, use the href-attribute
+                2. as a substitutionGroup for ddm:DdmRelationType. in that case, use the scheme attribute
 
-                    so either the href or scheme attribute MUST be provided
+                so either the href or scheme attribute MUST be provided
             </xs:documentation>
         </xs:annotation>
         <xs:complexType>
@@ -229,7 +229,7 @@
 
     <xs:complexType name="LinkedRelationType">
         <xs:complexContent>
-            <xs:extension base="ddm:NonEmptyString"> 
+            <xs:extension base="ddm:NonEmptyString">
                 <xs:attribute name="href" type="xs:anyURI">
                     <xs:annotation>
                         <xs:documentation>
@@ -240,7 +240,7 @@
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>
-    
+
     <xs:complexType name="NonEmptyString">
         <xs:simpleContent>
             <xs:restriction base="dc:SimpleLiteral">
@@ -359,6 +359,37 @@
             </xs:enumeration>
         </xs:restriction>
     </xs:simpleType>
+
+    <!-- =================================================================================== -->
+    <xs:element name="subject" substitutionGroup="dcterms:subject" type="ddm:SubjectType">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">Restriction on dcterms:subject. Use this instead of dcterms:subject when the subject-term adheres to a
+                formal subjectScheme.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:element>
+
+    <xs:complexType name="SubjectType">
+        <xs:complexContent>
+            <xs:extension base="dc:SimpleLiteral">
+                <xs:attribute name="schemeURI" use="required" type="xs:anyURI">
+                    <xs:annotation>
+                        <xs:documentation>The URI of the scheme. For a SKOS scheme, the ConceptScheme in the 'skos:inScheme' value is expected</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="valueURI" use="required" type="xs:anyURI">
+                    <xs:annotation>
+                        <xs:documentation>The URI of the value given in the text-node.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="subjectScheme" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>A human readable title of the scheme used.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
 
     <!-- =================================================================================== -->
 </xs:schema>

--- a/src/main/assembly/dist/md/ddm/ddm.xsd
+++ b/src/main/assembly/dist/md/ddm/ddm.xsd
@@ -181,10 +181,10 @@
         <xs:annotation>
             <xs:documentation>
                 This extension on dc:relation can be used in two ways:
-                    1. as a substitutionGroup for ddm:linkedRelation. in that case, use the href-attribute
-                    2. as a substitutionGroup for ddm:DdmRelationType. in that case, use the scheme attribute
+                1. as a substitutionGroup for ddm:linkedRelation. in that case, use the href-attribute
+                2. as a substitutionGroup for ddm:DdmRelationType. in that case, use the scheme attribute
 
-                    so either the href or scheme attribute MUST be provided
+                so either the href or scheme attribute MUST be provided
             </xs:documentation>
         </xs:annotation>
         <xs:complexType>
@@ -229,7 +229,7 @@
 
     <xs:complexType name="LinkedRelationType">
         <xs:complexContent>
-            <xs:extension base="ddm:NonEmptyString"> 
+            <xs:extension base="ddm:NonEmptyString">
                 <xs:attribute name="href" type="xs:anyURI">
                     <xs:annotation>
                         <xs:documentation>
@@ -240,7 +240,7 @@
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>
-    
+
     <xs:complexType name="NonEmptyString">
         <xs:simpleContent>
             <xs:restriction base="dc:SimpleLiteral">
@@ -359,6 +359,37 @@
             </xs:enumeration>
         </xs:restriction>
     </xs:simpleType>
+
+    <!-- =================================================================================== -->
+    <xs:element name="subject" substitutionGroup="dcterms:subject" type="ddm:SubjectType">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">Restriction on dcterms:subject. Use this instead of dcterms:subject when the subject-term adheres to a
+                formal subjectScheme.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:element>
+
+    <xs:complexType name="SubjectType">
+        <xs:complexContent>
+            <xs:extension base="dc:SimpleLiteral">
+                <xs:attribute name="schemeURI" use="required" type="xs:anyURI">
+                    <xs:annotation>
+                        <xs:documentation>The URI of the scheme. For a SKOS scheme, the ConceptScheme in the 'skos:inScheme' value is expected</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="valueURI" use="required" type="xs:anyURI">
+                    <xs:annotation>
+                        <xs:documentation>The URI of the value given in the text-node.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="subjectScheme" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>A human readable title of the scheme used.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
 
     <!-- =================================================================================== -->
 </xs:schema>


### PR DESCRIPTION
fixes EASY-1374

#### When applied it will
* add the definition for `ddm:subject` to the DDM
    * I have taken the liberty to add this to `2017-09` rather than making a new `2017-10`, since this (a) saves a couple extra PRs and (b) `2017-09` has not been taken into public use.
* apply some accidental formatting
* add an example for `ddm:subject`

@DANS-KNAW/easy for review
@lindareijnhoudt please review, merge, publish on easy01, release on artifactory and let me know the new version number on artifactory (probably 1.15.0?); thanks!