### PR TITLE
EASY-1457: Specify amd.xsd

### DIFF
--- a/src/main/assembly/dist/bag/metadata/amd/v0.1/amd.xsd
+++ b/src/main/assembly/dist/bag/metadata/amd/v0.1/amd.xsd
@@ -17,9 +17,10 @@
 
 -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
-    targetNamespace="http://easy.dans.knaw.nl/easy/dataset-administrative-metadata/"
-    xmlns:damd="http://easy.dans.knaw.nl/easy/dataset-administrative-metadata/" xmlns:wfs="http://easy.dans.knaw.nl/easy/workflow/">
-    <xs:import namespace="http://easy.dans.knaw.nl/easy/workflow/" schemaLocation="wfs.xsd"/>
+           targetNamespace="http://easy.dans.knaw.nl/easy/dataset-administrative-metadata/"
+           xmlns:damd="http://easy.dans.knaw.nl/easy/dataset-administrative-metadata/"
+           xmlns:wfs="http://easy.dans.knaw.nl/easy/workflow/">
+    <xs:import namespace="http://easy.dans.knaw.nl/easy/workflow/" schemaLocation="https://easy.dans.knaw.nl/schemas/bag/metadata/amd/v0.1/wfs.xsd"/>
     <!-- import the versioned schema of wfs -->
     <xs:annotation>
         <xs:documentation>Schema to describe the administrative metadata for datasets in EASY, version 0.1.</xs:documentation>
@@ -31,7 +32,7 @@
                 <xs:element name="previousState" form="unqualified" type="damd:DatasetStateType"/>
                 <xs:element name="depositorId" form="unqualified" type="xs:NCName" minOccurs="1" maxOccurs="1">
                     <xs:annotation>
-                        <xs:documentation>The username of the depositor. This is NOT the creator of the dataset. </xs:documentation>
+                        <xs:documentation>The username of the depositor. This is NOT the creator of the dataset.</xs:documentation>
                     </xs:annotation>
                 </xs:element>
                 <xs:element name="stateChangeDates" form="unqualified" minOccurs="0">
@@ -99,7 +100,7 @@
             </xs:enumeration>
             <xs:enumeration value="DELETED">
                 <xs:annotation>
-                    <xs:documentation> The dataset is not available. Only superuser can retrieve the dataset. </xs:documentation>
+                    <xs:documentation>The dataset is not available. Only superuser can retrieve the dataset.</xs:documentation>
                 </xs:annotation>
             </xs:enumeration>
         </xs:restriction>

--- a/src/main/assembly/dist/bag/metadata/amd/v0.1/amd.xsd
+++ b/src/main/assembly/dist/bag/metadata/amd/v0.1/amd.xsd
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
+    targetNamespace="http://easy.dans.knaw.nl/easy/dataset-administrative-metadata/"
+    xmlns:damd="http://easy.dans.knaw.nl/easy/dataset-administrative-metadata/" xmlns:wfs="http://easy.dans.knaw.nl/easy/workflow/">
+    <xs:import namespace="http://easy.dans.knaw.nl/easy/workflow/" schemaLocation="wfs.xsd"/>
+    <!-- import the versioned schema of wfs -->
+    <xs:annotation>
+        <xs:documentation>Schema to describe the administrative metadata for datasets in EASY, version 0.1.</xs:documentation>
+    </xs:annotation>
+    <xs:element name="administrative-md">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="datasetState" form="unqualified" type="damd:DatasetStateType"/>
+                <xs:element name="previousState" form="unqualified" type="damd:DatasetStateType"/>
+                <xs:element name="depositorId" form="unqualified" type="xs:NCName" minOccurs="1" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>The username of the depositor. This is NOT the creator of the dataset. </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="stateChangeDates" form="unqualified" minOccurs="0">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element maxOccurs="unbounded" ref="damd:stateChangeDate"/>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="groupIds" form="unqualified">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="group" type="xs:NCName" minOccurs="0"/>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element ref="damd:workflowData"/>
+            </xs:sequence>
+            <xs:attribute name="version" use="required" type="xs:string" fixed="0.1"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="stateChangeDate">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="fromState" form="unqualified" type="xs:NCName"/>
+                <xs:element name="toState" form="unqualified" type="xs:NCName"/>
+                <xs:element name="changeDate" form="unqualified" type="xs:dateTime"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="workflowData">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="assigneeId" form="unqualified" type="xs:NCName">
+                    <xs:annotation>
+                        <xs:documentation>The DANS data manager responsible for the curation of this dataset.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element ref="wfs:workflow"/>
+            </xs:sequence>
+            <xs:attribute name="version" use="required" type="xs:string" fixed="0.1"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:simpleType name="DatasetStateType">
+        <xs:restriction base="xs:NMTOKEN">
+            <xs:enumeration value="PUBLISHED">
+                <xs:annotation>
+                    <xs:documentation>The dataset is available for download. Conditions of Access apply</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="MAINTENANCE">
+                <xs:annotation>
+                    <xs:documentation>The dataset is not available for download.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="DRAFT">
+                <xs:annotation>
+                    <xs:documentation>The dataset has not yet been submitted, it can still be edited by the depositor.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="SUBMITTED">
+                <xs:annotation>
+                    <xs:documentation>Submitted by depositor, not available for download.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="DELETED">
+                <xs:annotation>
+                    <xs:documentation> The dataset is not available. Only superuser can retrieve the dataset. </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+</xs:schema>

--- a/src/main/assembly/dist/bag/metadata/amd/v0.1/amd.xsd
+++ b/src/main/assembly/dist/bag/metadata/amd/v0.1/amd.xsd
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2012 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
     targetNamespace="http://easy.dans.knaw.nl/easy/dataset-administrative-metadata/"
     xmlns:damd="http://easy.dans.knaw.nl/easy/dataset-administrative-metadata/" xmlns:wfs="http://easy.dans.knaw.nl/easy/workflow/">

--- a/src/main/assembly/dist/bag/metadata/amd/v0.1/wfs.xsd
+++ b/src/main/assembly/dist/bag/metadata/amd/v0.1/wfs.xsd
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://easy.dans.knaw.nl/easy/workflow/"
+    xmlns:wfs="http://easy.dans.knaw.nl/easy/workflow/">
+    <xs:annotation>
+        <xs:documentation>The administrative workflow used by DANS data managers, version 0.1</xs:documentation>
+    </xs:annotation>
+    <xs:element name="workflow">
+        <xs:complexType>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:element name="completed" form="unqualified" type="xs:boolean"/>
+                <xs:element name="completionTime" form="unqualified" type="xs:dateTime">
+                    <xs:annotation>
+                        <xs:documentation>The timestamp of marking this flow-step as completed.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="doneById" form="unqualified" type="xs:NCName">
+                    <xs:annotation>
+                        <xs:documentation>The DANS data manager responsible for this flow-step</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="id" form="unqualified" type="wfs:WorkflowStepType"/>
+                <xs:element name="remarks" form="unqualified">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element minOccurs="0" name="remark" form="unqualified">
+                                <xs:complexType>
+                                    <xs:sequence>
+                                        <xs:element name="text" form="unqualified" type="xs:string"/>
+                                        <xs:element name="remarkerId" form="unqualified" type="xs:NCName"/>
+                                        <xs:element name="remarkDate" form="unqualified" type="xs:dateTime"/>
+                                    </xs:sequence>
+                                </xs:complexType>
+                            </xs:element>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="required" form="unqualified" type="xs:boolean"/>
+                <xs:element name="steps" form="unqualified">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element minOccurs="0" maxOccurs="unbounded" ref="wfs:workflow"/>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="timeSpentWritable" form="unqualified" type="xs:boolean"/>
+            </xs:choice>
+        </xs:complexType>
+    </xs:element>
+    <!--  -->
+    <xs:simpleType name="WorkflowStepType">
+        <xs:restriction base="xs:NMTOKEN">
+            <xs:enumeration value="dataset">
+                <xs:annotation>
+                    <xs:documentation/>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="dataset.sip">
+                <xs:annotation>
+                    <xs:documentation/>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="dataset.sip.files">
+                <xs:annotation>
+                    <xs:documentation/>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="dataset.sip.files.completeness">
+                <xs:annotation>
+                    <xs:documentation>Controle op compleetheid aanlevering</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="dataset.sip.files.accessibility">
+                <xs:annotation>
+                    <xs:documentation>Controle op toegankelijkheid: leesbaarheid files, preferred formats</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="dataset.sip.files.privacy">
+                <xs:annotation>
+                    <xs:documentation>Controle op privacygevoelige informatie</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="dataset.sip.file-list">
+                <xs:annotation>
+                    <xs:documentation>Controle op bestandenlijst met individuele metadata van bestanden (optional)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="dataset.sip.file-list.file-metadata">
+                <xs:annotation>
+                    <xs:documentation/>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="dataset.sip.descriptive-metadata">
+                <xs:annotation>
+                    <xs:documentation/>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="dataset.sip.descriptive-metadata.completeness">
+                <xs:annotation>
+                    <xs:documentation>Controle op compleetheid, correctheid. Aanpassen indien gewenst.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="dataset.sip.descriptive-metadata.identifiers">
+                <xs:annotation>
+                    <xs:documentation>Identifiers: toewijzen van Intern Project Identifier (IPI) (optional)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="dataset.aip">
+                <xs:annotation>
+                    <xs:documentation/>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="dataset.aip.file-conversion">
+                <xs:annotation>
+                    <xs:documentation>Conversie van bestanden naar preferred formats; upload van "processed" (optional)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="dataset.aip.file-metadata">
+                <xs:annotation>
+                    <xs:documentation>Toevoegen van individuele file metadata (optional)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="dataset.aip.structure">
+                <xs:annotation>
+                    <xs:documentation>Structureren dataset tot een logisch geheel (optional)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="dataset.dip">
+                <xs:annotation>
+                    <xs:documentation/>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="dataset.dip.publish-files">
+                <xs:annotation>
+                    <xs:documentation>Visibility/Accessibility aanpassen voor (beschikbaar te stellen) bestanden</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="dataset.dip.jumpoff">
+                <xs:annotation>
+                    <xs:documentation>Opmaken/aanpassen jumpoff page (optional)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="dataset.dip.relations">
+                <xs:annotation>
+                    <xs:documentation>Koppelingen met gerelateerde pagina's aanmaken ("verzamelpagina's") (optional)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+</xs:schema>

--- a/src/main/assembly/dist/bag/metadata/amd/v0.1/wfs.xsd
+++ b/src/main/assembly/dist/bag/metadata/amd/v0.1/wfs.xsd
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2012 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://easy.dans.knaw.nl/easy/workflow/"
     xmlns:wfs="http://easy.dans.knaw.nl/easy/workflow/">
     <xs:annotation>

--- a/src/main/assembly/dist/bag/metadata/amd/v1.0/amd.xsd
+++ b/src/main/assembly/dist/bag/metadata/amd/v1.0/amd.xsd
@@ -30,7 +30,7 @@
             * delete: groupIds in the amd
             * delete: datasetState/previousState no longer recorded, as state is not a property to be archived
             * delete: stateChangeDates
-            * add: accessGranterId (TODO: better name)
+            * add: accessGranterId
         </xs:documentation>
     </xs:annotation>
     <xs:element name="administrative-md">
@@ -44,8 +44,8 @@
                 <xs:element name="accessGranterId" form="unqualified" type="xs:NCName" minOccurs="0" maxOccurs="1">
                     <xs:annotation>
                         <xs:documentation>
-                            The username of the owner of the dataset. This is the agent to be notified with questions regarding
-                            this dataset or its permissions. This is NOT necessarily the creator of the dataset.
+                            The agent to be notified with questions regarding this dataset or its permissions.
+                            This is NOT necessarily the creator of the dataset.
                             If no AccessGranter is specified, the depositor is notified.
                         </xs:documentation>
                     </xs:annotation>

--- a/src/main/assembly/dist/bag/metadata/amd/v1.0/amd.xsd
+++ b/src/main/assembly/dist/bag/metadata/amd/v1.0/amd.xsd
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
+    targetNamespace="http://easy.dans.knaw.nl/easy/dataset-administrative-metadata/"
+    xmlns:damd="http://easy.dans.knaw.nl/easy/dataset-administrative-metadata/" xmlns:wfs="http://easy.dans.knaw.nl/easy/workflow/">
+    <xs:import namespace="http://easy.dans.knaw.nl/easy/workflow/" schemaLocation="wfs.xsd"/>
+    <!-- import the versioned schema of wfs -->
+    <xs:annotation>
+        <xs:documentation>Schema to describe the administrative metadata for datasets in EASY, v1.0.
+            Changes from v0.1 to v1.0:
+            * delete: groupIds in the amd
+            * delete: datasetState/previousState no longer recorded, as state is not a property to be archived
+            * delete: stateChangeDates
+            * add: permissionGranterId (TODO: better name)
+        </xs:documentation>
+    </xs:annotation>
+    <xs:element name="administrative-md">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="depositorId" form="unqualified" type="xs:NCName" minOccurs="1" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>The username of the depositor. This is NOT the creator of the dataset. </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="permissionGranterId" form="unqualified" type="xs:NCName" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>The username of the owner of the dataset. This is the agent to be notified with questions regarding this dataset or its permissions. </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element ref="damd:workflowData"/>
+            </xs:sequence>
+            <xs:attribute name="version" use="required" type="xs:string" fixed="1.0"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="workflowData">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="assigneeId" form="unqualified" type="xs:NCName">
+                    <xs:annotation>
+                        <xs:documentation>The DANS data manager responsible for the curation of this dataset.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element ref="wfs:workflow"/>
+            </xs:sequence>
+            <xs:attribute name="version" use="required" type="xs:string" fixed="1.0"/>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/src/main/assembly/dist/bag/metadata/amd/v1.0/amd.xsd
+++ b/src/main/assembly/dist/bag/metadata/amd/v1.0/amd.xsd
@@ -17,12 +17,15 @@
 
 -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
-    targetNamespace="http://easy.dans.knaw.nl/easy/dataset-administrative-metadata/"
-    xmlns:damd="http://easy.dans.knaw.nl/easy/dataset-administrative-metadata/" xmlns:wfs="http://easy.dans.knaw.nl/easy/workflow/">
-    <xs:import namespace="http://easy.dans.knaw.nl/easy/workflow/" schemaLocation="wfs.xsd"/>
+           targetNamespace="http://easy.dans.knaw.nl/easy/dataset-administrative-metadata/"
+           xmlns:damd="http://easy.dans.knaw.nl/easy/dataset-administrative-metadata/"
+           xmlns:wfs="http://easy.dans.knaw.nl/easy/workflow/">
+    <xs:import namespace="http://easy.dans.knaw.nl/easy/workflow/" schemaLocation="https://easy.dans.knaw.nl/schemas/bag/metadata/amd/v1.0/wfs.xsd"/>
     <!-- import the versioned schema of wfs -->
     <xs:annotation>
-        <xs:documentation>Schema to describe the administrative metadata for datasets in EASY, v1.0.
+        <xs:documentation>
+            Schema to describe the administrative metadata for datasets in EASY, v1.0.
+
             Changes from v0.1 to v1.0:
             * delete: groupIds in the amd
             * delete: datasetState/previousState no longer recorded, as state is not a property to be archived
@@ -35,12 +38,15 @@
             <xs:sequence>
                 <xs:element name="depositorId" form="unqualified" type="xs:NCName" minOccurs="1" maxOccurs="1">
                     <xs:annotation>
-                        <xs:documentation>The username of the depositor. This is NOT the creator of the dataset. </xs:documentation>
+                        <xs:documentation>The username of the depositor. This is NOT the creator of the dataset.</xs:documentation>
                     </xs:annotation>
                 </xs:element>
                 <xs:element name="permissionGranterId" form="unqualified" type="xs:NCName" minOccurs="0" maxOccurs="1">
                     <xs:annotation>
-                        <xs:documentation>The username of the owner of the dataset. This is the agent to be notified with questions regarding this dataset or its permissions. </xs:documentation>
+                        <xs:documentation>
+                            The username of the owner of the dataset. This is the agent to be notified with questions regarding
+                            this dataset or its permissions.
+                        </xs:documentation>
                     </xs:annotation>
                 </xs:element>
                 <xs:element ref="damd:workflowData"/>

--- a/src/main/assembly/dist/bag/metadata/amd/v1.0/amd.xsd
+++ b/src/main/assembly/dist/bag/metadata/amd/v1.0/amd.xsd
@@ -30,7 +30,7 @@
             * delete: groupIds in the amd
             * delete: datasetState/previousState no longer recorded, as state is not a property to be archived
             * delete: stateChangeDates
-            * add: permissionGranterId (TODO: better name)
+            * add: accessGranterId (TODO: better name)
         </xs:documentation>
     </xs:annotation>
     <xs:element name="administrative-md">
@@ -38,14 +38,15 @@
             <xs:sequence>
                 <xs:element name="depositorId" form="unqualified" type="xs:NCName" minOccurs="1" maxOccurs="1">
                     <xs:annotation>
-                        <xs:documentation>The username of the depositor. This is NOT the creator of the dataset.</xs:documentation>
+                        <xs:documentation>The username of the depositor. This is NOT necessarily the creator of the dataset.</xs:documentation>
                     </xs:annotation>
                 </xs:element>
-                <xs:element name="permissionGranterId" form="unqualified" type="xs:NCName" minOccurs="0" maxOccurs="1">
+                <xs:element name="accessGranterId" form="unqualified" type="xs:NCName" minOccurs="0" maxOccurs="1">
                     <xs:annotation>
                         <xs:documentation>
                             The username of the owner of the dataset. This is the agent to be notified with questions regarding
-                            this dataset or its permissions.
+                            this dataset or its permissions. This is NOT necessarily the creator of the dataset.
+                            If no AccessGranter is specified, the depositor is notified.
                         </xs:documentation>
                     </xs:annotation>
                 </xs:element>

--- a/src/main/assembly/dist/bag/metadata/amd/v1.0/amd.xsd
+++ b/src/main/assembly/dist/bag/metadata/amd/v1.0/amd.xsd
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2012 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
     targetNamespace="http://easy.dans.knaw.nl/easy/dataset-administrative-metadata/"
     xmlns:damd="http://easy.dans.knaw.nl/easy/dataset-administrative-metadata/" xmlns:wfs="http://easy.dans.knaw.nl/easy/workflow/">

--- a/src/main/assembly/dist/bag/metadata/amd/v1.0/wfs.xsd
+++ b/src/main/assembly/dist/bag/metadata/amd/v1.0/wfs.xsd
@@ -17,13 +17,14 @@
 
 -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://easy.dans.knaw.nl/easy/workflow/"
-    xmlns:wfs="http://easy.dans.knaw.nl/easy/workflow/">
+           xmlns:wfs="http://easy.dans.knaw.nl/easy/workflow/">
     <xs:annotation>
-        <xs:documentation>The administrative workflow used by DANS data managers, v1.0 
-Changes from v0.1 to v1.0: 
+        <xs:documentation xml:lang="eng">
+            The administrative workflow used by DANS data managers, v1.0
+            Changes from v0.1 to v1.0:
 
-* Delete: Time spent is no longer recorded
-* Add: revisionID
+            * Delete: Time spent is no longer recorded
+            * Add: revisionID
         </xs:documentation>
     </xs:annotation>
     <xs:element name="workflow">
@@ -32,17 +33,17 @@ Changes from v0.1 to v1.0:
                 <xs:element name="completed" form="unqualified" type="xs:boolean"/>
                 <xs:element name="revisionId" form="unqualified" type="xs:string">
                     <xs:annotation>
-                        <xs:documentation>The identifier of the revision this curation-workflow was performed on.</xs:documentation>
+                        <xs:documentation xml:lang="eng">The identifier of the revision this curation-workflow was performed on.</xs:documentation>
                     </xs:annotation>
                 </xs:element>
                 <xs:element name="completionTime" form="unqualified" type="xs:dateTime">
                     <xs:annotation>
-                        <xs:documentation>The timestamp of marking this flow-step as completed.</xs:documentation>
+                        <xs:documentation xml:lang="eng">The timestamp of marking this flow-step as completed.</xs:documentation>
                     </xs:annotation>
                 </xs:element>
                 <xs:element name="doneById" form="unqualified" type="xs:NCName">
                     <xs:annotation>
-                        <xs:documentation>The DANS data manager responsible for this flow-step</xs:documentation>
+                        <xs:documentation xml:lang="eng">The DANS data manager responsible for this flow-step</xs:documentation>
                     </xs:annotation>
                 </xs:element>
                 <xs:element name="id" form="unqualified" type="wfs:WorkflowStepType"/>
@@ -74,99 +75,90 @@ Changes from v0.1 to v1.0:
     </xs:element>
     <xs:simpleType name="WorkflowStepType">
         <xs:restriction base="xs:NMTOKEN">
-            <xs:enumeration value="dataset">
-                <xs:annotation>
-                    <xs:documentation/>
-                </xs:annotation>
-            </xs:enumeration>
-            <xs:enumeration value="dataset.sip">
-                <xs:annotation>
-                    <xs:documentation/>
-                </xs:annotation>
-            </xs:enumeration>
-            <xs:enumeration value="dataset.sip.files">
-                <xs:annotation>
-                    <xs:documentation/>
-                </xs:annotation>
-            </xs:enumeration>
+            <xs:annotation>
+                <xs:documentation xml:lang="eng">
+                    The dutch text is identical to the text in the user interface.
+                    This is the actual text the data manager agrees to when ticking this workflow step as 'done'.
+                    DO NOT CHANGE
+                </xs:documentation>
+            </xs:annotation>
+            <xs:enumeration value="dataset"/>
+            <xs:enumeration value="dataset.sip"/>
+            <xs:enumeration value="dataset.sip.files"/>
             <xs:enumeration value="dataset.sip.files.completeness">
                 <xs:annotation>
-                    <xs:documentation>Controle op compleetheid aanlevering</xs:documentation>
+                    <xs:documentation xml:lang="dut">Controle op compleetheid aanlevering</xs:documentation>
+                    <xs:documentation xml:lang="eng">Check completeness of deposit-submission</xs:documentation>
                 </xs:annotation>
             </xs:enumeration>
             <xs:enumeration value="dataset.sip.files.accessibility">
                 <xs:annotation>
-                    <xs:documentation>Controle op toegankelijkheid: leesbaarheid files, preferred formats</xs:documentation>
+                    <xs:documentation xml:lang="dut">Controle op toegankelijkheid: leesbaarheid files, preferred formats</xs:documentation>
+                    <xs:documentation xml:lang="eng">Check accessibility: readability files, preferred formats</xs:documentation>
                 </xs:annotation>
             </xs:enumeration>
             <xs:enumeration value="dataset.sip.files.privacy">
                 <xs:annotation>
-                    <xs:documentation>Controle op privacygevoelige informatie</xs:documentation>
+                    <xs:documentation xml:lang="dut">Controle op privacygevoelige informatie</xs:documentation>
+                    <xs:documentation xml:lang="eng">Check for privacy sensitive information</xs:documentation>
                 </xs:annotation>
             </xs:enumeration>
             <xs:enumeration value="dataset.sip.file-list">
                 <xs:annotation>
-                    <xs:documentation>Controle op bestandenlijst met individuele metadata van bestanden (optional)</xs:documentation>
+                    <xs:documentation xml:lang="dut">Controle op bestandenlijst met individuele metadata van bestanden (optional)</xs:documentation>
+                    <xs:documentation xml:lang="eng">Check filelist with individual metadata on files (optional)</xs:documentation>
                 </xs:annotation>
             </xs:enumeration>
-            <xs:enumeration value="dataset.sip.file-list.file-metadata">
-                <xs:annotation>
-                    <xs:documentation/>
-                </xs:annotation>
-            </xs:enumeration>
-            <xs:enumeration value="dataset.sip.descriptive-metadata">
-                <xs:annotation>
-                    <xs:documentation/>
-                </xs:annotation>
-            </xs:enumeration>
+            <xs:enumeration value="dataset.sip.file-list.file-metadata"/>
+            <xs:enumeration value="dataset.sip.descriptive-metadata"/>
             <xs:enumeration value="dataset.sip.descriptive-metadata.completeness">
                 <xs:annotation>
-                    <xs:documentation>Controle op compleetheid, correctheid. Aanpassen indien gewenst.</xs:documentation>
+                    <xs:documentation xml:lang="dut">Controle op compleetheid, correctheid. Aanpassen indien gewenst.</xs:documentation>
+                    <xs:documentation xml:lang="eng">Check on completeness, correctness. Edit if so desired</xs:documentation>
                 </xs:annotation>
             </xs:enumeration>
             <xs:enumeration value="dataset.sip.descriptive-metadata.identifiers">
                 <xs:annotation>
-                    <xs:documentation>Identifiers: toewijzen van Intern Project Identifier (IPI) (optional)</xs:documentation>
+                    <xs:documentation xml:lang="dut">Identifiers: toewijzen van Intern Project Identifier (IPI) (optional)</xs:documentation>
+                    <xs:documentation xml:lang="eng">Identifiers: assign Intern Project Identifier (IPI) (optional)</xs:documentation>
                 </xs:annotation>
             </xs:enumeration>
-            <xs:enumeration value="dataset.aip">
-                <xs:annotation>
-                    <xs:documentation/>
-                </xs:annotation>
-            </xs:enumeration>
+            <xs:enumeration value="dataset.aip"/>
             <xs:enumeration value="dataset.aip.file-conversion">
                 <xs:annotation>
-                    <xs:documentation>Conversie van bestanden naar preferred formats; upload van "processed" (optional)</xs:documentation>
+                    <xs:documentation xml:lang="dut">Conversie van bestanden naar preferred formats; upload van "processed" (optional)</xs:documentation>
+                    <xs:documentation xml:lang="eng">Convert files to preferred format; upload "processed" files (optional)</xs:documentation>
                 </xs:annotation>
             </xs:enumeration>
             <xs:enumeration value="dataset.aip.file-metadata">
                 <xs:annotation>
-                    <xs:documentation>Toevoegen van individuele file metadata (optional)</xs:documentation>
+                    <xs:documentation xml:lang="dut">Toevoegen van individuele file metadata (optional)</xs:documentation>
+                    <xs:documentation xml:lang="eng">Add individual file metadata (optional)</xs:documentation>
                 </xs:annotation>
             </xs:enumeration>
             <xs:enumeration value="dataset.aip.structure">
                 <xs:annotation>
-                    <xs:documentation>Structureren dataset tot een logisch geheel (optional)</xs:documentation>
+                    <xs:documentation xml:lang="dut">Structureren dataset tot een logisch geheel (optional)</xs:documentation>
+                    <xs:documentation xml:lang="eng">Reorganize deposit into a coherent structure</xs:documentation>
                 </xs:annotation>
             </xs:enumeration>
-            <xs:enumeration value="dataset.dip">
-                <xs:annotation>
-                    <xs:documentation/>
-                </xs:annotation>
-            </xs:enumeration>
+            <xs:enumeration value="dataset.dip"/>
             <xs:enumeration value="dataset.dip.publish-files">
                 <xs:annotation>
-                    <xs:documentation>Visibility/Accessibility aanpassen voor (beschikbaar te stellen) bestanden</xs:documentation>
+                    <xs:documentation xml:lang="dut">Visibility/Accessibility aanpassen voor (beschikbaar te stellen) bestanden</xs:documentation>
+                    <xs:documentation xml:lang="eng">Edit visibility/accessibility on files</xs:documentation>
                 </xs:annotation>
             </xs:enumeration>
             <xs:enumeration value="dataset.dip.jumpoff">
                 <xs:annotation>
-                    <xs:documentation>Opmaken/aanpassen jumpoff page (optional)</xs:documentation>
+                    <xs:documentation xml:lang="dut">Opmaken/aanpassen jumpoff page (optional)</xs:documentation>
+                    <xs:documentation xml:lang="eng">Edit jumpoff page (optional)</xs:documentation>
                 </xs:annotation>
             </xs:enumeration>
             <xs:enumeration value="dataset.dip.relations">
                 <xs:annotation>
-                    <xs:documentation>Koppelingen met gerelateerde pagina's aanmaken ("verzamelpagina's") (optional)</xs:documentation>
+                    <xs:documentation xml:lang="dut">Koppelingen met gerelateerde pagina's aanmaken ("verzamelpagina's") (optional)</xs:documentation>
+                    <xs:documentation xml:lang="eng">Add relations (isPartOf) with other datasets ("verzamelpagina", i.e. a set of datasets) (optional)</xs:documentation>
                 </xs:annotation>
             </xs:enumeration>
         </xs:restriction>

--- a/src/main/assembly/dist/bag/metadata/amd/v1.0/wfs.xsd
+++ b/src/main/assembly/dist/bag/metadata/amd/v1.0/wfs.xsd
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2012 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://easy.dans.knaw.nl/easy/workflow/"
     xmlns:wfs="http://easy.dans.knaw.nl/easy/workflow/">
     <xs:annotation>

--- a/src/main/assembly/dist/bag/metadata/amd/v1.0/wfs.xsd
+++ b/src/main/assembly/dist/bag/metadata/amd/v1.0/wfs.xsd
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://easy.dans.knaw.nl/easy/workflow/"
+    xmlns:wfs="http://easy.dans.knaw.nl/easy/workflow/">
+    <xs:annotation>
+        <xs:documentation>The administrative workflow used by DANS data managers, v1.0 
+Changes from v0.1 to v1.0: 
+
+* Delete: Time spent is no longer recorded
+* Add: revisionID
+        </xs:documentation>
+    </xs:annotation>
+    <xs:element name="workflow">
+        <xs:complexType>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:element name="completed" form="unqualified" type="xs:boolean"/>
+                <xs:element name="revisionId" form="unqualified" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>The identifier of the revision this curation-workflow was performed on.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="completionTime" form="unqualified" type="xs:dateTime">
+                    <xs:annotation>
+                        <xs:documentation>The timestamp of marking this flow-step as completed.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="doneById" form="unqualified" type="xs:NCName">
+                    <xs:annotation>
+                        <xs:documentation>The DANS data manager responsible for this flow-step</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="id" form="unqualified" type="wfs:WorkflowStepType"/>
+                <xs:element name="remarks" form="unqualified">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element minOccurs="0" name="remark" form="unqualified">
+                                <xs:complexType>
+                                    <xs:sequence>
+                                        <xs:element name="text" form="unqualified" type="xs:string"/>
+                                        <xs:element name="remarkerId" form="unqualified" type="xs:NCName"/>
+                                        <xs:element name="remarkDate" form="unqualified" type="xs:dateTime"/>
+                                    </xs:sequence>
+                                </xs:complexType>
+                            </xs:element>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="required" form="unqualified" type="xs:boolean"/>
+                <xs:element name="steps" form="unqualified">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element minOccurs="0" maxOccurs="unbounded" ref="wfs:workflow"/>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+            </xs:choice>
+        </xs:complexType>
+    </xs:element>
+    <xs:simpleType name="WorkflowStepType">
+        <xs:restriction base="xs:NMTOKEN">
+            <xs:enumeration value="dataset">
+                <xs:annotation>
+                    <xs:documentation/>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="dataset.sip">
+                <xs:annotation>
+                    <xs:documentation/>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="dataset.sip.files">
+                <xs:annotation>
+                    <xs:documentation/>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="dataset.sip.files.completeness">
+                <xs:annotation>
+                    <xs:documentation>Controle op compleetheid aanlevering</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="dataset.sip.files.accessibility">
+                <xs:annotation>
+                    <xs:documentation>Controle op toegankelijkheid: leesbaarheid files, preferred formats</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="dataset.sip.files.privacy">
+                <xs:annotation>
+                    <xs:documentation>Controle op privacygevoelige informatie</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="dataset.sip.file-list">
+                <xs:annotation>
+                    <xs:documentation>Controle op bestandenlijst met individuele metadata van bestanden (optional)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="dataset.sip.file-list.file-metadata">
+                <xs:annotation>
+                    <xs:documentation/>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="dataset.sip.descriptive-metadata">
+                <xs:annotation>
+                    <xs:documentation/>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="dataset.sip.descriptive-metadata.completeness">
+                <xs:annotation>
+                    <xs:documentation>Controle op compleetheid, correctheid. Aanpassen indien gewenst.</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="dataset.sip.descriptive-metadata.identifiers">
+                <xs:annotation>
+                    <xs:documentation>Identifiers: toewijzen van Intern Project Identifier (IPI) (optional)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="dataset.aip">
+                <xs:annotation>
+                    <xs:documentation/>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="dataset.aip.file-conversion">
+                <xs:annotation>
+                    <xs:documentation>Conversie van bestanden naar preferred formats; upload van "processed" (optional)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="dataset.aip.file-metadata">
+                <xs:annotation>
+                    <xs:documentation>Toevoegen van individuele file metadata (optional)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="dataset.aip.structure">
+                <xs:annotation>
+                    <xs:documentation>Structureren dataset tot een logisch geheel (optional)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="dataset.dip">
+                <xs:annotation>
+                    <xs:documentation/>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="dataset.dip.publish-files">
+                <xs:annotation>
+                    <xs:documentation>Visibility/Accessibility aanpassen voor (beschikbaar te stellen) bestanden</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="dataset.dip.jumpoff">
+                <xs:annotation>
+                    <xs:documentation>Opmaken/aanpassen jumpoff page (optional)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="dataset.dip.relations">
+                <xs:annotation>
+                    <xs:documentation>Koppelingen met gerelateerde pagina's aanmaken ("verzamelpagina's") (optional)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+</xs:schema>


### PR DESCRIPTION
fixes EASY-1457

#### When applied it will
* retro specify amd.xsd and wfs.xsd as v0.1
* add amd.xsd and wfs.xsd v1.0 

#### Where should the reviewer @DANS-KNAW/easy start?
    WFS: Changes from v0.1 to v1.0:

    * Delete: Time spent is no longer recorded
    * Add: revisionID

    AMD: Changes from v0.1 to v1.0:
    * delete: groupIds in the amd
    * delete: datasetState/previousState no longer recorded, as state is not a property to be archived
    * delete: stateChangeDates
    * add: accessGranterId (TODO: better name)

#### How should this be manually tested?
