### PR TITLE
NO JIRA Fixed problem with version file.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,16 @@
     </pluginRepositories>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/assembly/dist</directory>
+                <targetPath>${project.build.directory}/version</targetPath>
+                <includes>
+                    <include>version</include>
+                </includes>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
@@ -104,6 +114,9 @@
             <build>
                 <plugins>
                     <plugin>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                    </plugin>
+                    <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>rpm-maven-plugin</artifactId>
                         <configuration>
@@ -122,6 +135,14 @@
                                 </mapping>
                             </mappings>
                         </configuration>
+                        <executions>
+                            <execution>
+                                <id>attach-rpm</id>
+                                <goals>
+                                    <goal>attached-rpm</goal>
+                                </goals>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
When migrating to the new parent pom, some configuration was lost:

* The resources-element that puts the filtered version-file at target/version/version
* Attaching the RPM plugin to the build

