### PR TITLE
EASY-2205: Allow scheme attribute on all ddm:relationTypes

### DIFF
--- a/src/main/assembly/dist/md/2019/07/ddm.xsd
+++ b/src/main/assembly/dist/md/2019/07/ddm.xsd
@@ -230,7 +230,7 @@
         <xs:restriction base="xs:NMTOKEN">
             <xs:annotation>
                 <xs:documentation>
-                    For the first five values, see http://easy.dans.knaw.nl/schemas/vocab/identifier-type/ for the documentation on the allowed elements                
+                    For the first five values, see https://easy.dans.knaw.nl/schemas/vocab/2017/identifier-type.xsd for the documentation on the allowed elements
                     Use STREAMING_SURROGATE_RELATION for the location on the video streaming service.
                 </xs:documentation>
             </xs:annotation>

--- a/src/main/assembly/dist/md/2019/07/ddm.xsd
+++ b/src/main/assembly/dist/md/2019/07/ddm.xsd
@@ -248,7 +248,7 @@
                         </xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
-                <xs:attribute name="scheme" type="ddm:LinkedRelationTypeSchema" use="required" default="URL"/>
+                <xs:attribute name="scheme" type="ddm:LinkedRelationTypeSchema" use="required"/>
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>

--- a/src/main/assembly/dist/md/ddm/ddm.xsd
+++ b/src/main/assembly/dist/md/ddm/ddm.xsd
@@ -228,7 +228,7 @@
         <xs:restriction base="xs:NMTOKEN">
             <xs:annotation>
                 <xs:documentation>
-                    For the first five values, see http://easy.dans.knaw.nl/schemas/vocab/identifier-type/ for the documentation on the allowed elements                
+                    For the first five values, see https://easy.dans.knaw.nl/schemas/vocab/2017/identifier-type.xsd for the documentation on the allowed elements
                     Use STREAMING_SURROGATE_RELATION for the location on the video streaming service.
                 </xs:documentation>
             </xs:annotation>

--- a/src/main/assembly/dist/md/ddm/ddm.xsd
+++ b/src/main/assembly/dist/md/ddm/ddm.xsd
@@ -263,7 +263,7 @@
         </xs:simpleContent>
     </xs:complexType>
 
-<xs:element name="relation" substitutionGroup="ddm:linkedRelation"/>
+    <xs:element name="relation" substitutionGroup="ddm:linkedRelation"/>
     <xs:element name="conformsTo" substitutionGroup="ddm:linkedRelation"/>
     <xs:element name="hasFormat" substitutionGroup="ddm:linkedRelation"/>
     <xs:element name="hasPart" substitutionGroup="ddm:linkedRelation"/>

--- a/src/main/assembly/dist/md/ddm/ddm.xsd
+++ b/src/main/assembly/dist/md/ddm/ddm.xsd
@@ -55,14 +55,13 @@
             Change since 2017/09
             * Add ddm:temporal
 
-
             Copyright (c) 2012 DANS-KNAW
         </xs:documentation>
     </xs:annotation>
 
     <!-- =================================================================================== -->
     <xs:import namespace="http://www.w3.org/XML/1998/namespace"
-               schemaLocation="http://www.w3.org/2001/03/xml.xsd"/>    
+               schemaLocation="http://www.w3.org/2001/03/xml.xsd"/>
     <!-- this schema location is temporary, since the original (http://dublincore.org/schemas/xmls/qdc/dc.xsd) is not available -->
     <xs:import namespace="http://purl.org/dc/elements/1.1/"
                schemaLocation="http://dublincore.org/schemas/xmls/qdc/2008/02/11/dc.xsd"/>

--- a/src/main/assembly/dist/md/ddm/ddm.xsd
+++ b/src/main/assembly/dist/md/ddm/ddm.xsd
@@ -26,7 +26,6 @@
            xmlns:id-type="http://easy.dans.knaw.nl/schemas/vocab/identifier-type/"
            xmlns:datacite="http://datacite.org/schema/kernel-4"
            targetNamespace="http://easy.dans.knaw.nl/schemas/md/ddm/"
-           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            elementFormDefault="qualified" attributeFormDefault="unqualified">
 
     <!-- =================================================================================== -->
@@ -248,7 +247,7 @@
                         </xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
-                <xs:attribute name="scheme" type="ddm:LinkedRelationTypeSchema" use="required" default="URL"/>
+                <xs:attribute name="scheme" type="ddm:LinkedRelationTypeSchema" use="optional" default="URL"/>
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>


### PR DESCRIPTION
fixes EASY-2205

#### When applied it will
* Allow scheme attribute on all ddm:relationTypes

The values are restricted to a regex pattern. the Streaming-surrogate-relation is still allowed on ddm:relation. However it is now allowed on all other relation-types too, though it should not be used there.
The values allowed can be expressed with or without a namespace-like prefix. However, this is not really a namespace as it is part of a string. 

I do not know a better way to do this. I've updated the examples too, to show what i wanted to achieve with this change. It is designed to be backwards compatible, so all previously accepted ddm files should still validate
 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-schema-examples                      | [PR#5](https://github.com/DANS-KNAW/easy-schema-examples/pull/5) 
