### PR TITLE
EASY-2240: Update http to https for dublincore to avoid 301 Moved Permanently

### DIFF
--- a/src/main/assembly/dist/bag/metadata/agreements/2018/05/agreements.xsd
+++ b/src/main/assembly/dist/bag/metadata/agreements/2018/05/agreements.xsd
@@ -19,7 +19,7 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:dcterms="http://purl.org/dc/terms/" elementFormDefault="qualified"
     xmlns:am="http://easy.dans.knaw.nl/schemas/bag/metadata/agreements/"
     targetNamespace="http://easy.dans.knaw.nl/schemas/bag/metadata/agreements/">
-    <xs:import namespace="http://purl.org/dc/terms/" schemaLocation="http://dublincore.org/schemas/xmls/qdc/2008/02/11/dcterms.xsd"/>
+    <xs:import namespace="http://purl.org/dc/terms/" schemaLocation="https://dublincore.org/schemas/xmls/qdc/2008/02/11/dcterms.xsd"/>
     <xs:annotation>
         <xs:documentation>
             This schema specifies a metadata-format for describing the agreements between the depositor and DANS-KNAW.

--- a/src/main/assembly/dist/bag/metadata/agreements/2018/12/agreements.xsd
+++ b/src/main/assembly/dist/bag/metadata/agreements/2018/12/agreements.xsd
@@ -19,7 +19,7 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:dcterms="http://purl.org/dc/terms/" elementFormDefault="qualified"
     xmlns:am="http://easy.dans.knaw.nl/schemas/bag/metadata/agreements/"
     targetNamespace="http://easy.dans.knaw.nl/schemas/bag/metadata/agreements/">
-    <xs:import namespace="http://purl.org/dc/terms/" schemaLocation="http://dublincore.org/schemas/xmls/qdc/2008/02/11/dcterms.xsd"/>
+    <xs:import namespace="http://purl.org/dc/terms/" schemaLocation="https://dublincore.org/schemas/xmls/qdc/2008/02/11/dcterms.xsd"/>
     <xs:annotation>
         <xs:documentation>
             This schema specifies a metadata-format for describing the agreements between the depositor and DANS-KNAW.

--- a/src/main/assembly/dist/bag/metadata/agreements/2019/01/agreements.xsd
+++ b/src/main/assembly/dist/bag/metadata/agreements/2019/01/agreements.xsd
@@ -19,7 +19,7 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:dcterms="http://purl.org/dc/terms/" elementFormDefault="qualified"
            xmlns:am="http://easy.dans.knaw.nl/schemas/bag/metadata/agreements/"
            targetNamespace="http://easy.dans.knaw.nl/schemas/bag/metadata/agreements/">
-    <xs:import namespace="http://purl.org/dc/terms/" schemaLocation="http://dublincore.org/schemas/xmls/qdc/2008/02/11/dcterms.xsd"/>
+    <xs:import namespace="http://purl.org/dc/terms/" schemaLocation="https://dublincore.org/schemas/xmls/qdc/2008/02/11/dcterms.xsd"/>
     <xs:annotation>
         <xs:documentation>
             This schema specifies a metadata-format for describing the agreements between the depositor and DANS-KNAW.

--- a/src/main/assembly/dist/bag/metadata/agreements/agreements.xsd
+++ b/src/main/assembly/dist/bag/metadata/agreements/agreements.xsd
@@ -19,7 +19,7 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:dcterms="http://purl.org/dc/terms/" elementFormDefault="qualified"
     xmlns:am="http://easy.dans.knaw.nl/schemas/bag/metadata/agreements/"
     targetNamespace="http://easy.dans.knaw.nl/schemas/bag/metadata/agreements/">
-    <xs:import namespace="http://purl.org/dc/terms/" schemaLocation="http://dublincore.org/schemas/xmls/qdc/2008/02/11/dcterms.xsd"/>
+    <xs:import namespace="http://purl.org/dc/terms/" schemaLocation="https://dublincore.org/schemas/xmls/qdc/2008/02/11/dcterms.xsd"/>
     <xs:annotation>
         <xs:documentation>
             This schema specifies a metadata-format for describing the agreements between the depositor and DANS-KNAW.

--- a/src/main/assembly/dist/bag/metadata/files/2017/09/files.xsd
+++ b/src/main/assembly/dist/bag/metadata/files/2017/09/files.xsd
@@ -33,10 +33,10 @@
 
     <!-- =================================================================================== -->
     <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/03/xml.xsd"/>
-    <!-- this schema location is temporary, since the original (http://dublincore.org/schemas/xmls/qdc/dc.xsd) is not available -->
-    <xs:import namespace="http://purl.org/dc/elements/1.1/" schemaLocation="http://dublincore.org/schemas/xmls/qdc/2008/02/11/dc.xsd"/>
-    <!-- this schema location is temporary, since the original (http://dublincore.org/schemas/xmls/qdc/dcterms.xsd) is not available -->
-    <xs:import namespace="http://purl.org/dc/terms/" schemaLocation="http://dublincore.org/schemas/xmls/qdc/2008/02/11/dcterms.xsd"/>
+    <!-- this schema location is temporary, since the original (https://dublincore.org/schemas/xmls/qdc/dc.xsd) is not available -->
+    <xs:import namespace="http://purl.org/dc/elements/1.1/" schemaLocation="https://dublincore.org/schemas/xmls/qdc/2008/02/11/dc.xsd"/>
+    <!-- this schema location is temporary, since the original (https://dublincore.org/schemas/xmls/qdc/dcterms.xsd) is not available -->
+    <xs:import namespace="http://purl.org/dc/terms/" schemaLocation="https://dublincore.org/schemas/xmls/qdc/2008/02/11/dcterms.xsd"/>
     <!-- =================================================================================== -->
     <xs:element name="files">
         <xs:complexType>

--- a/src/main/assembly/dist/bag/metadata/files/2018/02/files.xsd
+++ b/src/main/assembly/dist/bag/metadata/files/2018/02/files.xsd
@@ -41,10 +41,10 @@
 
     <!-- =================================================================================== -->
     <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/03/xml.xsd"/>
-    <!-- this schema location is temporary, since the original (http://dublincore.org/schemas/xmls/qdc/dc.xsd) is not available -->
-    <xs:import namespace="http://purl.org/dc/elements/1.1/" schemaLocation="http://dublincore.org/schemas/xmls/qdc/2008/02/11/dc.xsd"/>
-    <!-- this schema location is temporary, since the original (http://dublincore.org/schemas/xmls/qdc/dcterms.xsd) is not available -->
-    <xs:import namespace="http://purl.org/dc/terms/" schemaLocation="http://dublincore.org/schemas/xmls/qdc/2008/02/11/dcterms.xsd"/>
+    <!-- this schema location is temporary, since the original (https://dublincore.org/schemas/xmls/qdc/dc.xsd) is not available -->
+    <xs:import namespace="http://purl.org/dc/elements/1.1/" schemaLocation="https://dublincore.org/schemas/xmls/qdc/2008/02/11/dc.xsd"/>
+    <!-- this schema location is temporary, since the original (https://dublincore.org/schemas/xmls/qdc/dcterms.xsd) is not available -->
+    <xs:import namespace="http://purl.org/dc/terms/" schemaLocation="https://dublincore.org/schemas/xmls/qdc/2008/02/11/dcterms.xsd"/>
     <!-- =================================================================================== -->
     <xs:element name="files">
         <xs:complexType>

--- a/src/main/assembly/dist/bag/metadata/files/2018/04/files.xsd
+++ b/src/main/assembly/dist/bag/metadata/files/2018/04/files.xsd
@@ -41,10 +41,10 @@
 
     <!-- =================================================================================== -->
     <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/03/xml.xsd"/>
-    <!-- this schema location is temporary, since the original (http://dublincore.org/schemas/xmls/qdc/dc.xsd) is not available -->
-    <xs:import namespace="http://purl.org/dc/elements/1.1/" schemaLocation="http://dublincore.org/schemas/xmls/qdc/2008/02/11/dc.xsd"/>
-    <!-- this schema location is temporary, since the original (http://dublincore.org/schemas/xmls/qdc/dcterms.xsd) is not available -->
-    <xs:import namespace="http://purl.org/dc/terms/" schemaLocation="http://dublincore.org/schemas/xmls/qdc/2008/02/11/dcterms.xsd"/>
+    <!-- this schema location is temporary, since the original (https://dublincore.org/schemas/xmls/qdc/dc.xsd) is not available -->
+    <xs:import namespace="http://purl.org/dc/elements/1.1/" schemaLocation="https://dublincore.org/schemas/xmls/qdc/2008/02/11/dc.xsd"/>
+    <!-- this schema location is temporary, since the original (https://dublincore.org/schemas/xmls/qdc/dcterms.xsd) is not available -->
+    <xs:import namespace="http://purl.org/dc/terms/" schemaLocation="https://dublincore.org/schemas/xmls/qdc/2008/02/11/dcterms.xsd"/>
     <!-- =================================================================================== -->
     <xs:element name="files">
         <xs:complexType>

--- a/src/main/assembly/dist/bag/metadata/files/files.xsd
+++ b/src/main/assembly/dist/bag/metadata/files/files.xsd
@@ -42,9 +42,9 @@
     <!-- =================================================================================== -->
     <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/03/xml.xsd"/>
     <!-- this schema location is temporary, since the original (http://dublincore.org/schemas/xmls/qdc/dc.xsd) is not available -->
-    <xs:import namespace="http://purl.org/dc/elements/1.1/" schemaLocation="http://dublincore.org/schemas/xmls/qdc/2008/02/11/dc.xsd"/>
+    <xs:import namespace="http://purl.org/dc/elements/1.1/" schemaLocation="https://dublincore.org/schemas/xmls/qdc/2008/02/11/dc.xsd"/>
     <!-- this schema location is temporary, since the original (http://dublincore.org/schemas/xmls/qdc/dcterms.xsd) is not available -->
-    <xs:import namespace="http://purl.org/dc/terms/" schemaLocation="http://dublincore.org/schemas/xmls/qdc/2008/02/11/dcterms.xsd"/>
+    <xs:import namespace="http://purl.org/dc/terms/" schemaLocation="https://dublincore.org/schemas/xmls/qdc/2008/02/11/dcterms.xsd"/>
     <!-- =================================================================================== -->
     <xs:element name="files">
         <xs:complexType>

--- a/src/main/assembly/dist/bag/metadata/files/files.xsd
+++ b/src/main/assembly/dist/bag/metadata/files/files.xsd
@@ -41,9 +41,9 @@
 
     <!-- =================================================================================== -->
     <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/03/xml.xsd"/>
-    <!-- this schema location is temporary, since the original (http://dublincore.org/schemas/xmls/qdc/dc.xsd) is not available -->
+    <!-- this schema location is temporary, since the original (https://dublincore.org/schemas/xmls/qdc/dc.xsd) is not available -->
     <xs:import namespace="http://purl.org/dc/elements/1.1/" schemaLocation="https://dublincore.org/schemas/xmls/qdc/2008/02/11/dc.xsd"/>
-    <!-- this schema location is temporary, since the original (http://dublincore.org/schemas/xmls/qdc/dcterms.xsd) is not available -->
+    <!-- this schema location is temporary, since the original (https://dublincore.org/schemas/xmls/qdc/dcterms.xsd) is not available -->
     <xs:import namespace="http://purl.org/dc/terms/" schemaLocation="https://dublincore.org/schemas/xmls/qdc/2008/02/11/dcterms.xsd"/>
     <!-- =================================================================================== -->
     <xs:element name="files">

--- a/src/main/assembly/dist/dcx/2012/10/dcx-dai.xsd
+++ b/src/main/assembly/dist/dcx/2012/10/dcx-dai.xsd
@@ -36,7 +36,7 @@
     <xs:import namespace="http://easy.dans.knaw.nl/schemas/dcx/"
                schemaLocation="http://easy.dans.knaw.nl/schemas/dcx/2012/10/dcx.xsd"/>
     <xs:import namespace="http://purl.org/dc/elements/1.1/"
-               schemaLocation="http://dublincore.org/schemas/xmls/qdc/dc.xsd"/>
+               schemaLocation="https://dublincore.org/schemas/xmls/qdc/dc.xsd"/>
 
     <!-- =================================================================================== -->
     <xs:element name="creator" substitutionGroup="dc:creator" type="dcx-dai:DAIType">

--- a/src/main/assembly/dist/dcx/2012/10/dcx-gml.xsd
+++ b/src/main/assembly/dist/dcx/2012/10/dcx-gml.xsd
@@ -34,7 +34,7 @@
     <xs:import namespace="http://easy.dans.knaw.nl/schemas/dcx/"
                schemaLocation="http://easy.dans.knaw.nl/schemas/dcx/2012/10/dcx.xsd"/>
     <xs:import namespace="http://purl.org/dc/terms/"
-               schemaLocation="http://dublincore.org/schemas/xmls/qdc/dcterms.xsd"/>
+               schemaLocation="https://dublincore.org/schemas/xmls/qdc/dcterms.xsd"/>
     <xs:import namespace="http://www.opengis.net/gml"
                schemaLocation="http://schemas.opengis.net/gml/3.1.1/profiles/gmlsfProfile/1.0.0/gmlsf.xsd"/>
 

--- a/src/main/assembly/dist/dcx/2012/10/dcx.xsd
+++ b/src/main/assembly/dist/dcx/2012/10/dcx.xsd
@@ -31,7 +31,7 @@
     <xs:import namespace="http://www.w3.org/XML/1998/namespace"
                schemaLocation="http://www.w3.org/2001/03/xml.xsd"/>
     <xs:import namespace="http://purl.org/dc/elements/1.1/"
-               schemaLocation="http://dublincore.org/schemas/xmls/qdc/dc.xsd"/>
+               schemaLocation="https://dublincore.org/schemas/xmls/qdc/dc.xsd"/>
 
     <!-- =================================================================================== -->
     <xs:complexType name="NoLanguageAttributeType">

--- a/src/main/assembly/dist/dcx/2016/dcx-gml.xsd
+++ b/src/main/assembly/dist/dcx/2016/dcx-gml.xsd
@@ -34,7 +34,7 @@
     <xs:import namespace="http://easy.dans.knaw.nl/schemas/dcx/"
                schemaLocation="http://easy.dans.knaw.nl/schemas/dcx/2012/10/dcx.xsd"/>
     <xs:import namespace="http://purl.org/dc/terms/"
-               schemaLocation="http://dublincore.org/schemas/xmls/qdc/dcterms.xsd"/>
+               schemaLocation="https://dublincore.org/schemas/xmls/qdc/dcterms.xsd"/>
     <xs:import namespace="http://www.opengis.net/gml"
                schemaLocation="http://schemas.opengis.net/gml/3.1.1/profiles/gmlsfProfile/1.0.0/gmlsf.xsd"/>
 

--- a/src/main/assembly/dist/dcx/2017/09/dcx-dai.xsd
+++ b/src/main/assembly/dist/dcx/2017/09/dcx-dai.xsd
@@ -37,7 +37,7 @@
     <xs:import namespace="http://easy.dans.knaw.nl/schemas/dcx/"
                schemaLocation="http://easy.dans.knaw.nl/schemas/dcx/2012/10/dcx.xsd"/>
     <xs:import namespace="http://purl.org/dc/elements/1.1/"
-               schemaLocation="http://dublincore.org/schemas/xmls/qdc/dc.xsd"/>
+               schemaLocation="https://dublincore.org/schemas/xmls/qdc/dc.xsd"/>
     <xs:import namespace="http://datacite.org/schema/kernel-4"
                schemaLocation="https://schema.datacite.org/meta/kernel-4/metadata.xsd"/>
 

--- a/src/main/assembly/dist/dcx/2018/03/dcx-dai.xsd
+++ b/src/main/assembly/dist/dcx/2018/03/dcx-dai.xsd
@@ -40,7 +40,7 @@
     <xs:import namespace="http://easy.dans.knaw.nl/schemas/dcx/"
                schemaLocation="http://easy.dans.knaw.nl/schemas/dcx/2012/10/dcx.xsd"/>
     <xs:import namespace="http://purl.org/dc/elements/1.1/"
-               schemaLocation="http://dublincore.org/schemas/xmls/qdc/dc.xsd"/>
+               schemaLocation="https://dublincore.org/schemas/xmls/qdc/dc.xsd"/>
     <xs:import namespace="http://datacite.org/schema/kernel-4"
                schemaLocation="https://schema.datacite.org/meta/kernel-4/metadata.xsd"/>
 

--- a/src/main/assembly/dist/dcx/2019/01/dcx-dai.xsd
+++ b/src/main/assembly/dist/dcx/2019/01/dcx-dai.xsd
@@ -47,7 +47,7 @@
     <xs:import namespace="http://easy.dans.knaw.nl/schemas/dcx/"
                schemaLocation="http://easy.dans.knaw.nl/schemas/dcx/2012/10/dcx.xsd"/>
     <xs:import namespace="http://purl.org/dc/elements/1.1/"
-               schemaLocation="http://dublincore.org/schemas/xmls/qdc/dc.xsd"/>
+               schemaLocation="https://dublincore.org/schemas/xmls/qdc/dc.xsd"/>
     <xs:import namespace="http://datacite.org/schema/kernel-4"
                schemaLocation="http://schema.datacite.org/meta/kernel-4/metadata.xsd"/>
 

--- a/src/main/assembly/dist/dcx/dcx-dai.xsd
+++ b/src/main/assembly/dist/dcx/dcx-dai.xsd
@@ -47,7 +47,7 @@
     <xs:import namespace="http://easy.dans.knaw.nl/schemas/dcx/"
                schemaLocation="http://easy.dans.knaw.nl/schemas/dcx/2012/10/dcx.xsd"/>
     <xs:import namespace="http://purl.org/dc/elements/1.1/"
-               schemaLocation="http://dublincore.org/schemas/xmls/qdc/dc.xsd"/>
+               schemaLocation="https://dublincore.org/schemas/xmls/qdc/dc.xsd"/>
     <xs:import namespace="http://datacite.org/schema/kernel-4"
                schemaLocation="http://schema.datacite.org/meta/kernel-4/metadata.xsd"/>
 

--- a/src/main/assembly/dist/dcx/dcx-gml.xsd
+++ b/src/main/assembly/dist/dcx/dcx-gml.xsd
@@ -34,7 +34,7 @@
     <xs:import namespace="http://easy.dans.knaw.nl/schemas/dcx/"
                schemaLocation="http://easy.dans.knaw.nl/schemas/dcx/2012/10/dcx.xsd"/>
     <xs:import namespace="http://purl.org/dc/terms/"
-               schemaLocation="http://dublincore.org/schemas/xmls/qdc/dcterms.xsd"/>
+               schemaLocation="https://dublincore.org/schemas/xmls/qdc/dcterms.xsd"/>
     <xs:import namespace="http://www.opengis.net/gml"
                schemaLocation="http://schemas.opengis.net/gml/3.1.1/profiles/gmlsfProfile/1.0.0/gmlsf.xsd"/>
 

--- a/src/main/assembly/dist/md/2012/10/ddm.xsd
+++ b/src/main/assembly/dist/md/2012/10/ddm.xsd
@@ -43,9 +43,9 @@
     <xs:import namespace="http://www.w3.org/XML/1998/namespace"
         schemaLocation="http://www.w3.org/2001/03/xml.xsd"/>
     <xs:import namespace="http://purl.org/dc/elements/1.1/"
-        schemaLocation="http://dublincore.org/schemas/xmls/qdc/dc.xsd"/>
+        schemaLocation="https://dublincore.org/schemas/xmls/qdc/dc.xsd"/>
     <xs:import namespace="http://purl.org/dc/terms/"
-        schemaLocation="http://dublincore.org/schemas/xmls/qdc/dcterms.xsd"/>
+        schemaLocation="https://dublincore.org/schemas/xmls/qdc/dcterms.xsd"/>
     <xs:import namespace="http://easy.dans.knaw.nl/schemas/dcx/" 
         schemaLocation="http://eof12.dans.knaw.nl/schemas/dcx/2012/10/dcx.xsd"/>
     <xs:import namespace="info:eu-repo/dai"
@@ -87,8 +87,8 @@
                             Where applicable the use of the xml:lang attribute is recommended.
                             Where applicable the use of the xsi:type attribute is recommended.
                             See also:
-                            http://dublincore.org/documents/dcmi-terms/
-                            http://dublincore.org/schemas/xmls/qdc/dcterms.xsd
+                            https://dublincore.org/documents/dcmi-terms/
+                            https://dublincore.org/schemas/xmls/qdc/dcterms.xsd
                             http://eof12.dans.knaw.nl/schemas/vocab/2012/10/abr-type.xsd (Archeologisch-Basisregister)
                             http://eof12.dans.knaw.nl/schemas/vocab/2012/10/narcis-type.xsd (NARCIS classification)
                         </xs:documentation>

--- a/src/main/assembly/dist/md/2012/11/ddm.xsd
+++ b/src/main/assembly/dist/md/2012/11/ddm.xsd
@@ -43,9 +43,9 @@
     <xs:import namespace="http://www.w3.org/XML/1998/namespace"
         schemaLocation="http://www.w3.org/2001/03/xml.xsd"/>
     <xs:import namespace="http://purl.org/dc/elements/1.1/"
-        schemaLocation="http://dublincore.org/schemas/xmls/qdc/dc.xsd"/>
+        schemaLocation="https://dublincore.org/schemas/xmls/qdc/dc.xsd"/>
     <xs:import namespace="http://purl.org/dc/terms/"
-        schemaLocation="http://dublincore.org/schemas/xmls/qdc/dcterms.xsd"/>
+        schemaLocation="https://dublincore.org/schemas/xmls/qdc/dcterms.xsd"/>
     <xs:import namespace="http://easy.dans.knaw.nl/schemas/dcx/" 
         schemaLocation="http://easy.dans.knaw.nl/schemas/dcx/2012/10/dcx.xsd"/>
     <xs:import namespace="http://easy.dans.knaw.nl/schemas/dcx/dai/" 
@@ -83,8 +83,8 @@
                             Where applicable the use of the xml:lang attribute is recommended.
                             Where applicable the use of the xsi:type attribute is recommended.
                             See also:
-                            http://dublincore.org/documents/dcmi-terms/
-                            http://dublincore.org/schemas/xmls/qdc/dcterms.xsd
+                            https://dublincore.org/documents/dcmi-terms/
+                            https://dublincore.org/schemas/xmls/qdc/dcterms.xsd
                         </xs:documentation>
                     </xs:annotation>
                 </xs:element>

--- a/src/main/assembly/dist/md/ddm/ddm.xsd
+++ b/src/main/assembly/dist/md/ddm/ddm.xsd
@@ -68,7 +68,7 @@
     <xs:import namespace="http://easy.dans.knaw.nl/schemas/dcx/"
                schemaLocation="http://easy.dans.knaw.nl/schemas/dcx/2012/10/dcx.xsd"/>
     <xs:import namespace="http://easy.dans.knaw.nl/schemas/dcx/dai/"
-               schemaLocation="http://easy.dans.knaw.nl/schemas/dcx/2019/01/dcx-dai.xsd"/>
+               schemaLocation="http://easy.dans.knaw.nl/schemas/dcx/dcx-dai.xsd"/>
     <xs:import namespace="http://easy.dans.knaw.nl/schemas/vocab/narcis-type/"
                schemaLocation="http://easy.dans.knaw.nl/schemas/vocab/2015/narcis-type.xsd"/>
     <xs:import namespace="http://easy.dans.knaw.nl/schemas/vocab/identifier-type/"
@@ -76,7 +76,7 @@
     <xs:import namespace="http://www.den.nl/standaard/166/Archeologisch-Basisregister/"
                schemaLocation="http://easy.dans.knaw.nl/schemas/vocab/2012/abr-type.xsd"/>
     <xs:import namespace="http://easy.dans.knaw.nl/schemas/dcx/gml/"
-               schemaLocation="http://easy.dans.knaw.nl/schemas/dcx/2016/dcx-gml.xsd"/>
+               schemaLocation="http://easy.dans.knaw.nl/schemas/dcx/dcx-gml.xsd"/>
     <xs:import namespace="http://datacite.org/schema/kernel-4"
                schemaLocation="http://schema.datacite.org/meta/kernel-4.1/metadata.xsd"/>
     <!-- =================================================================================== -->

--- a/src/main/assembly/dist/md/ddm/ddm.xsd
+++ b/src/main/assembly/dist/md/ddm/ddm.xsd
@@ -61,10 +61,10 @@
                schemaLocation="http://www.w3.org/2001/03/xml.xsd"/>
     <!-- this schema location is temporary, since the original (http://dublincore.org/schemas/xmls/qdc/dc.xsd) is not available -->
     <xs:import namespace="http://purl.org/dc/elements/1.1/"
-               schemaLocation="http://dublincore.org/schemas/xmls/qdc/2008/02/11/dc.xsd"/>
+               schemaLocation="https://dublincore.org/schemas/xmls/qdc/2008/02/11/dc.xsd"/>
     <!-- this schema location is temporary, since the original (http://dublincore.org/schemas/xmls/qdc/dcterms.xsd) is not available -->
     <xs:import namespace="http://purl.org/dc/terms/"
-               schemaLocation="http://dublincore.org/schemas/xmls/qdc/2008/02/11/dcterms.xsd"/>
+               schemaLocation="https://dublincore.org/schemas/xmls/qdc/2008/02/11/dcterms.xsd"/>
     <xs:import namespace="http://easy.dans.knaw.nl/schemas/dcx/"
                schemaLocation="http://easy.dans.knaw.nl/schemas/dcx/2012/10/dcx.xsd"/>
     <xs:import namespace="http://easy.dans.knaw.nl/schemas/dcx/dai/"

--- a/src/main/assembly/dist/vocab/2012/10/abr-type.xsd
+++ b/src/main/assembly/dist/vocab/2012/10/abr-type.xsd
@@ -26,7 +26,7 @@
     <xs:import namespace="http://www.w3.org/XML/1998/namespace"
         schemaLocation="http://www.w3.org/2001/03/xml.xsd"/> 
     <xs:import namespace="http://purl.org/dc/elements/1.1/" 
-    	schemaLocation="http://dublincore.org/schemas/xmls/qdc/dc.xsd"/>
+    	schemaLocation="https://dublincore.org/schemas/xmls/qdc/dc.xsd"/>
     
 	<!-- =================================================================================== -->
     <xs:annotation>

--- a/src/main/assembly/dist/vocab/2012/10/narcis-type.xsd
+++ b/src/main/assembly/dist/vocab/2012/10/narcis-type.xsd
@@ -28,7 +28,7 @@
     </xs:annotation>
 
     <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/03/xml.xsd"/>
-    <xs:import namespace="http://purl.org/dc/elements/1.1/" schemaLocation="http://dublincore.org/schemas/xmls/qdc/dc.xsd"/>
+    <xs:import namespace="http://purl.org/dc/elements/1.1/" schemaLocation="https://dublincore.org/schemas/xmls/qdc/dc.xsd"/>
 
     <xs:complexType name="DisciplineType">
         <xs:annotation>

--- a/src/main/assembly/dist/vocab/2012/abr-type.xsd
+++ b/src/main/assembly/dist/vocab/2012/abr-type.xsd
@@ -26,7 +26,7 @@
         schemaLocation="http://www.w3.org/2001/03/xml.xsd"/> 
 
     <xs:import namespace="http://purl.org/dc/elements/1.1/" 
-    	schemaLocation="http://dublincore.org/schemas/xmls/qdc/dc.xsd"/>
+    	schemaLocation="https://dublincore.org/schemas/xmls/qdc/dc.xsd"/>
     
     <xs:annotation>
         <xs:documentation>

--- a/src/main/assembly/dist/vocab/2015/narcis-type.xsd
+++ b/src/main/assembly/dist/vocab/2015/narcis-type.xsd
@@ -30,7 +30,7 @@
     <xs:import namespace="http://www.w3.org/XML/1998/namespace"
         schemaLocation="http://www.w3.org/2001/03/xml.xsd"/>
     <xs:import namespace="http://purl.org/dc/elements/1.1/"
-        schemaLocation="http://dublincore.org/schemas/xmls/qdc/dc.xsd"/>
+        schemaLocation="https://dublincore.org/schemas/xmls/qdc/dc.xsd"/>
 
     <xs:complexType name="DisciplineType">
         <xs:annotation>

--- a/src/main/assembly/dist/vocab/2017/09/identifier-type.xsd
+++ b/src/main/assembly/dist/vocab/2017/09/identifier-type.xsd
@@ -24,7 +24,7 @@
 
     <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/03/xml.xsd"/>
 
-    <xs:import namespace="http://purl.org/dc/elements/1.1/" schemaLocation="http://dublincore.org/schemas/xmls/qdc/dc.xsd"/>
+    <xs:import namespace="http://purl.org/dc/elements/1.1/" schemaLocation="https://dublincore.org/schemas/xmls/qdc/dc.xsd"/>
 
     <xs:complexType name="DOI">
         <xs:simpleContent>

--- a/src/main/assembly/dist/vocab/2017/identifier-type.xsd
+++ b/src/main/assembly/dist/vocab/2017/identifier-type.xsd
@@ -24,7 +24,7 @@
     
     <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/03/xml.xsd"/> 
     
-    <xs:import namespace="http://purl.org/dc/elements/1.1/" schemaLocation="http://dublincore.org/schemas/xmls/qdc/dc.xsd"/>
+    <xs:import namespace="http://purl.org/dc/elements/1.1/" schemaLocation="https://dublincore.org/schemas/xmls/qdc/dc.xsd"/>
     
     <xs:complexType name="DOI">
         <xs:simpleContent>

--- a/src/main/assembly/dist/vocab/2019/01/narcis-type.xsd
+++ b/src/main/assembly/dist/vocab/2019/01/narcis-type.xsd
@@ -39,7 +39,7 @@
     <xs:import namespace="http://www.w3.org/XML/1998/namespace"
         schemaLocation="http://www.w3.org/2001/03/xml.xsd"/>
     <xs:import namespace="http://purl.org/dc/elements/1.1/"
-        schemaLocation="http://dublincore.org/schemas/xmls/qdc/dc.xsd"/>
+        schemaLocation="https://dublincore.org/schemas/xmls/qdc/dc.xsd"/>
 
     <xs:complexType name="DisciplineType">
         <xs:annotation>

--- a/src/main/assembly/dist/vocab/narcis-type.xsd
+++ b/src/main/assembly/dist/vocab/narcis-type.xsd
@@ -39,7 +39,7 @@
     <xs:import namespace="http://www.w3.org/XML/1998/namespace"
         schemaLocation="http://www.w3.org/2001/03/xml.xsd"/>
     <xs:import namespace="http://purl.org/dc/elements/1.1/"
-        schemaLocation="http://dublincore.org/schemas/xmls/qdc/dc.xsd"/>
+        schemaLocation="https://dublincore.org/schemas/xmls/qdc/dc.xsd"/>
 
     <xs:complexType name="DisciplineType">
         <xs:annotation>


### PR DESCRIPTION
EASY-2240

#### When applied it will
* Update http to https to avoid 301 Moved Permanently

Since this redirection will break validation as the SaxParser does not seem to follow the 301

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-ddm                      | [PR#](PRlink) 
