### PR TITLE
EASY-2674: copy ddm.xsd from 2020/03/23/ddm.xsd to 2020/03/ddm.xsd to ensure backwards compatibility

### DIFF
--- a/lib/src/main/resources/md/2020/03/ddm.xsd
+++ b/lib/src/main/resources/md/2020/03/ddm.xsd
@@ -1,0 +1,459 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2012 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:ddm="http://easy.dans.knaw.nl/schemas/md/ddm/"
+           xmlns:dc="http://purl.org/dc/elements/1.1/"
+           xmlns:dcterms="http://purl.org/dc/terms/"
+           xmlns:dcx="http://easy.dans.knaw.nl/schemas/dcx/"
+           xmlns:dcx-dai="http://easy.dans.knaw.nl/schemas/dcx/dai/"
+           xmlns:narcis="http://easy.dans.knaw.nl/schemas/vocab/narcis-type/"
+           xmlns:id-type="http://easy.dans.knaw.nl/schemas/vocab/identifier-type/"
+           xmlns:datacite="http://datacite.org/schema/kernel-4"
+           targetNamespace="http://easy.dans.knaw.nl/schemas/md/ddm/"
+           elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+    <!-- =================================================================================== -->
+    <xs:annotation>
+        <xs:documentation xml:lang="en">DANS Dataset Metadata (DDM)
+
+            This schema specifies a metadata-format for describing datasets.
+            An instance of this metadata-format can be used for ingest of datasets with the Sword protocol.
+
+            Created 2012-10-26
+            Last modified 2020-23-03
+            
+            Change since 2020/03/03
+            * Add Funding element
+
+            Change since 2019/10
+            * no longer allow an X as 17th digit, lowercase 'x' is no longer allowed
+
+            Change since 2019/07
+            * Remove GROUP_ACCESS from EasyAccessCategoryType
+            * Remove 'group' attribute from ddm:accessRights
+
+            Change since 2019/01
+            * allow scheme attribute in all ddm:LinkedRelationType, restricted to known EASY-schemes
+
+            Change since 2018/05
+            * Upgrade to 2019/01/dcx-dai
+            * Upgrade to datacite v4.1
+
+            Change since 2018/03
+            * Add attribute 'group' in ddm:accessRights
+
+            Change since 2018/02
+            * Use 2018/03/dcx-dai.xsd
+            * Introduce ddm:description and add descriptionType-attribute
+
+            Change since 2017/09
+            * Add ddm:temporal
+
+            Copyright (c) 2012 DANS-KNAW
+        </xs:documentation>
+    </xs:annotation>
+
+    <!-- =================================================================================== -->
+    <xs:import namespace="http://www.w3.org/XML/1998/namespace"
+               schemaLocation="http://www.w3.org/2001/03/xml.xsd"/>
+    <!-- this schema location is temporary, since the original (https://dublincore.org/schemas/xmls/qdc/dc.xsd) is not available -->
+    <xs:import namespace="http://purl.org/dc/elements/1.1/"
+               schemaLocation="https://dublincore.org/schemas/xmls/qdc/2008/02/11/dc.xsd"/>
+    <!-- this schema location is temporary, since the original (https://dublincore.org/schemas/xmls/qdc/dcterms.xsd) is not available -->
+    <xs:import namespace="http://purl.org/dc/terms/"
+               schemaLocation="https://dublincore.org/schemas/xmls/qdc/2008/02/11/dcterms.xsd"/>
+    <xs:import namespace="http://easy.dans.knaw.nl/schemas/dcx/"
+               schemaLocation="http://easy.dans.knaw.nl/schemas/dcx/2012/10/dcx.xsd"/>
+    <xs:import namespace="http://easy.dans.knaw.nl/schemas/dcx/dai/"
+               schemaLocation="http://easy.dans.knaw.nl/schemas/dcx/2020/03/dcx-dai.xsd"/>
+    <xs:import namespace="http://easy.dans.knaw.nl/schemas/vocab/narcis-type/"
+               schemaLocation="http://easy.dans.knaw.nl/schemas/vocab/2015/narcis-type.xsd"/>
+    <xs:import namespace="http://easy.dans.knaw.nl/schemas/vocab/identifier-type/"
+               schemaLocation="http://easy.dans.knaw.nl/schemas/vocab/2017/09/identifier-type.xsd"/>
+    <xs:import namespace="http://www.den.nl/standaard/166/Archeologisch-Basisregister/"
+               schemaLocation="http://easy.dans.knaw.nl/schemas/vocab/2012/abr-type.xsd"/>
+    <xs:import namespace="http://easy.dans.knaw.nl/schemas/dcx/gml/"
+               schemaLocation="http://easy.dans.knaw.nl/schemas/dcx/2016/dcx-gml.xsd"/>
+    <xs:import namespace="http://datacite.org/schema/kernel-4"
+               schemaLocation="http://schema.datacite.org/meta/kernel-4.1/metadata.xsd"/>
+    <!-- =================================================================================== -->
+    <xs:element name="DDM">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                Root element of DANS Dataset Metadata. DDM-instances MUST have one ddm:profile element and MAY have
+                one ddm:dcmiMetadata element and one ddm:additional-xml element.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:all>
+                <xs:element name="profile" type="ddm:profileType">
+                    <xs:annotation>
+                        <xs:documentation xml:lang="en">
+                            Container for Easy-specific information. (Required)
+                            The information in this group is essential for profiling the dataset in the Easy application.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="dcmiMetadata" type="dcterms:elementOrRefinementContainer" minOccurs="0">
+                    <xs:annotation>
+                        <xs:documentation xml:lang="en">
+                            Container for dcmi metadata. (Optional)
+
+                            All elements of the http://purl.org/dc/elements/1.1/ namespace can be used.
+                            All elements of the http://purl.org/dc/terms/ namespace can be used.
+                            All elements defined in this schema that are extensions or restrictions of dc or dcterms elements can be used.
+
+                            Where applicable the use of the xml:lang attribute is recommended.
+                            Where applicable the use of the xsi:type attribute is recommended.
+                            See also:
+                            https://dublincore.org/documents/dcmi-terms/
+                            https://dublincore.org/schemas/xmls/qdc/dcterms.xsd
+                        </xs:documentation>
+                        <xs:documentation xml:lang="en">
+                            Some xml-elements from the dc and dcterms namespace have possible values for the xsi:type attribute that will be interpreted during ingest.
+                            <p xmlns="http://www.w3.org/1999/xhtml">
+                                <dl>
+                                    <dt>dc:identifier</dt>
+                                    <dd>can have an xsi:type from the "id-type" namespace. This will be interpreted as described there.</dd>
+                                    <dt>dc:language</dt>
+                                    <dd>can have xsi-type="dcterms:ISO639-2". It should then be formatted accordingly: <a href="https://www.loc.gov/standards/iso639-2/php/code_list.php">ISO639-2</a>.
+                                        Both `B` and `T` variants are supported.
+                                    </dd>
+                                    <dt>dc:format</dt>
+                                    <dd>can have an xsi:type="dcterms:IMT" if the value provided is valid according to that vocabulary</dd>
+                                    <dt>dcterms:type</dt>
+                                    <dd>can have an xsi:type="dcterms:DCMIType". Only values from the set {`Collection`, `Dataset`, `Event`, `Image`,
+                                        `InteractiveResource`, `MovingImage`, `PhysicalObject`, `Service`, `Software`, `Sound`, `StillImage`, `Text`} are
+                                        valid.
+                                    </dd>
+                                    <dt>dc:license | dcterms:license</dt>
+                                    <dd>At most one license-node is allowed. If xsi:type="dcterms:URI" is provided, this URI should denote a known license.</dd>
+                                </dl>
+                            </p>
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element ref="ddm:additional-xml" minOccurs="0"/>
+            </xs:all>
+        </xs:complexType>
+    </xs:element>
+
+    <!-- =================================================================================== -->
+    <xs:element name="description" substitutionGroup="dc:description">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                Restriction on dcterms:description.
+                If used, the descriptionType attribute is required.
+                Use dcterms:description otherwise.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="ddm:NonEmptyString">
+                    <xs:attribute name="descriptionType" type="datacite:descriptionType" use="required"/>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <!-- =================================================================================== -->
+    <xs:element name="created" substitutionGroup="dcterms:created" type="dcterms:W3CDTF">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                Restriction on dcterms:created.
+
+                Element value MUST conform to the dcterms:W3CDTF format.
+
+                See also: http://purl.org/dc/terms/created
+            </xs:documentation>
+        </xs:annotation>
+    </xs:element>
+
+    <!-- =================================================================================== -->
+    <xs:element name="available" substitutionGroup="dcterms:available" type="dcterms:W3CDTF">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                Restriction on dcterms:available.
+
+                Element value MUST conform to the dcterms:W3CDTF format.
+
+                See also: http://purl.org/dc/terms/available
+            </xs:documentation>
+        </xs:annotation>
+    </xs:element>
+
+    <!-- =================================================================================== -->
+    <xs:element name="audience" substitutionGroup="dcterms:audience" type="narcis:DisciplineType">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                Restriction on dcterms:audience.
+
+                Element value MUST conform to the narcis:DisciplineType.
+
+                See also: http://purl.org/dc/terms/audience
+            </xs:documentation>
+        </xs:annotation>
+    </xs:element>
+
+    <!-- =================================================================================== -->
+    <xs:element name="accessRights" type="ddm:EasyAccessRightsType">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                Use as substitute for dcterms:accessRights.
+
+                Element value MUST conform to ddm:EasyAccessRightsType.
+
+                See also: http://purl.org/dc/terms/accessRights
+            </xs:documentation>
+        </xs:annotation>
+    </xs:element>
+    <!-- =================================================================================== -->
+    <xs:element name="funding" substitutionGroup="dcterms:contributor" type="ddm:FundingReferenceType"/>
+    
+    <xs:complexType name="FundingReferenceType">
+        <xs:complexContent>
+            <xs:extension base="dcx:ElementsOnlyNoLanguageAttributeType">
+                <xs:sequence>
+                    <xs:element name="funderName" minOccurs="1"/>
+                    <xs:element name="funderIdentifier" minOccurs="0" maxOccurs="unbounded">
+                        <xs:complexType>
+                            <xs:simpleContent>
+                                <xs:extension base="xs:string">
+                                    <xs:attribute name="funderIdentifierType"
+                                        type="datacite:funderIdentifierType" use="required"/>
+                                </xs:extension>
+                            </xs:simpleContent>
+                        </xs:complexType>
+                    </xs:element>
+                    <xs:element name="fundingProgramme" minOccurs="0"/>
+                    <xs:element name="awardNumber" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>The code assigned by the funder to a sponsored award
+                                (grant).</xs:documentation>
+                        </xs:annotation>
+                        <xs:complexType>
+                            <xs:simpleContent>
+                                <xs:extension base="xs:string">
+                                    <xs:attribute name="awardURI" type="xs:anyURI" use="optional"/>
+                                </xs:extension>
+                            </xs:simpleContent>
+                        </xs:complexType>
+                    </xs:element>
+                    <xs:element name="awardTitle" minOccurs="0">
+                        <xs:complexType>
+                            <xs:simpleContent>
+                                <xs:extension base="xs:string">
+                                    <xs:attribute name="acronym" type="xs:string" use="optional"/>
+                                    <xs:attribute ref="xml:lang" use="required"/>
+                                </xs:extension>
+                            </xs:simpleContent>
+                        </xs:complexType>
+                    </xs:element>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <!-- =================================================================================== -->
+    <xs:element name="linkedRelation" substitutionGroup="dc:relation" type="ddm:LinkedRelationType">
+        <xs:annotation>
+            <xs:documentation>
+                all dcterms relation types can also extend this linkedRelation,
+                and take a 'href' attribute to include a webresource and a required scheme to indicate the scheme of the related identifier. If only the webresource is known, use @scheme=URL
+            </xs:documentation>
+        </xs:annotation>
+    </xs:element>
+
+    <xs:simpleType name="LinkedRelationTypeSchema">
+        <xs:restriction base="xs:NMTOKEN">
+            <xs:annotation>
+                <xs:documentation>
+                    For the first five values, see https://easy.dans.knaw.nl/schemas/vocab/2017/identifier-type.xsd for the documentation on the allowed elements
+                    Use STREAMING_SURROGATE_RELATION for the location on the video streaming service.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:pattern value="([-a-z:A-Z]*:*(DOI|ARCHIS-ZAAK-IDENTIFICATIE|URN|ISSN|ISBN|URI|URL))|STREAMING_SURROGATE_RELATION"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="LinkedRelationType">
+        <xs:complexContent>
+            <xs:extension base="ddm:NonEmptyString">
+                <xs:attribute name="href" type="xs:anyURI" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The URI of the relation.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="scheme" type="ddm:LinkedRelationTypeSchema"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="NonEmptyString">
+        <xs:simpleContent>
+            <xs:restriction base="dc:SimpleLiteral">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:minLength value="1"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:restriction>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:element name="relation" substitutionGroup="ddm:linkedRelation"/>
+    <xs:element name="conformsTo" substitutionGroup="ddm:linkedRelation"/>
+    <xs:element name="hasFormat" substitutionGroup="ddm:linkedRelation"/>
+    <xs:element name="hasPart" substitutionGroup="ddm:linkedRelation"/>
+    <xs:element name="hasVersion" substitutionGroup="ddm:linkedRelation"/>
+    <xs:element name="isFormatOf" substitutionGroup="ddm:linkedRelation"/>
+    <xs:element name="isPartOf" substitutionGroup="ddm:linkedRelation"/>
+    <xs:element name="isReferencedBy" substitutionGroup="ddm:linkedRelation"/>
+    <xs:element name="isReplacedBy" substitutionGroup="ddm:linkedRelation"/>
+    <xs:element name="isRequiredBy" substitutionGroup="ddm:linkedRelation"/>
+    <xs:element name="isVersionOf" substitutionGroup="ddm:linkedRelation"/>
+    <xs:element name="references" substitutionGroup="ddm:linkedRelation"/>
+    <xs:element name="replaces" substitutionGroup="ddm:linkedRelation"/>
+    <xs:element name="requires" substitutionGroup="ddm:linkedRelation"/>
+
+    <!-- =================================================================================== -->
+    <xs:element name="additional-xml">
+        <xs:annotation>
+            <xs:documentation>
+                Any valid xml-element will do as a child of this element, as long as its namespace is ##other.
+                If a schemaLocation is provided on the element, validating agents will validate the provided xml against that schema.
+                The element may be complex.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:any namespace="##other" processContents="lax" maxOccurs="unbounded"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <!-- =================================================================================== -->
+    <xs:complexType name="profileType">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                Detailed specification of the information that is essential for profiling the dataset in the Easy application.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element ref="dc:title" maxOccurs="unbounded"/>
+            <xs:element ref="dc:description" maxOccurs="unbounded"/>
+            <xs:element ref="dc:creator" maxOccurs="unbounded"/>
+            <xs:element ref="ddm:created"/>
+            <xs:element ref="ddm:available"/>
+            <xs:element ref="ddm:audience" maxOccurs="unbounded"/>
+            <xs:element ref="ddm:accessRights"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <!-- =================================================================================== -->
+    <xs:complexType name="EasyAccessRightsType">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                Use on dcterms:accessRights or members of its substitutionGroup.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:simpleContent>
+            <xs:extension base="ddm:EasyAccessCategoryType">
+                <xs:attribute ref="xml:lang" use="prohibited"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <!-- =================================================================================== -->
+    <xs:simpleType name="EasyAccessCategoryType">
+        <xs:restriction base="xs:NMTOKEN">
+            <xs:enumeration value="OPEN_ACCESS">
+                <xs:annotation>
+                    <xs:documentation>
+                        Unrestricted access.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="OPEN_ACCESS_FOR_REGISTERED_USERS">
+                <xs:annotation>
+                    <xs:documentation>
+                        Deprecated, kept for backwards compatibility. Unrestricted access for all registered EASY users.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="REQUEST_PERMISSION">
+                <xs:annotation>
+                    <xs:documentation>
+                        Registered EASY users, but only after depositor permission is granted.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="NO_ACCESS">
+                <xs:annotation>
+                    <xs:documentation>
+                        The data are not available via Easy (they are either accessible in another way or elsewhere).
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <!-- =================================================================================== -->
+    <xs:element name="subject" substitutionGroup="dcterms:subject" type="ddm:SubjectType">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">Restriction on dcterms:subject. Use this instead of dcterms:subject when the subject-term adheres to a
+                formal subjectScheme.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:element>
+
+    <xs:complexType name="SubjectType">
+        <xs:complexContent>
+            <xs:extension base="dc:SimpleLiteral">
+                <xs:attribute name="schemeURI" use="required" type="xs:anyURI">
+                    <xs:annotation>
+                        <xs:documentation>The URI of the scheme. For a SKOS scheme, the ConceptScheme in the 'skos:inScheme' value is expected</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="valueURI" use="required" type="xs:anyURI">
+                    <xs:annotation>
+                        <xs:documentation>The URI of the value given in the text-node.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="subjectScheme" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>A human readable title of the scheme used.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <!-- =================================================================================== -->
+
+    <xs:element name="temporal" substitutionGroup="dcterms:temporal" type="ddm:SubjectType">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">Restriction on dcterms:temporal. Use this instead of dcterms:temporal when the temporal-term adheres to a
+                formal scheme.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:element>
+    <!-- =================================================================================== -->
+</xs:schema>


### PR DESCRIPTION
fixes EASY-2674
fixes mistake made in #82 

#### When applied it will
* copy `ddm.xsd` from `2020/03/23/ddm.xsd` to `2020/03/ddm.xsd` to ensure backwards compatibility

@DANS-KNAW/easy for review