### PR TITLE
EASY-2787: Allow both EDNA-PROJECT as eDNA-project as id-type

### DIFF
--- a/lib/src/main/resources/vocab/2020/identifier-type.xsd
+++ b/lib/src/main/resources/vocab/2020/identifier-type.xsd
@@ -157,6 +157,20 @@
         </xs:simpleContent>
     </xs:complexType>
 
+    <xs:complexType name="EDNA-PROJECT">
+        <xs:annotation>
+            <xs:documentation>Deprecated. Use 'eDNA-project' instead.</xs:documentation>
+        </xs:annotation>
+        <xs:simpleContent>
+            <xs:restriction base="dc:SimpleLiteral">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string"/>
+                </xs:simpleType>
+                <xs:attribute ref="xml:lang" use="prohibited"/>
+            </xs:restriction>
+        </xs:simpleContent>
+    </xs:complexType>
+
     <xs:complexType name="ARCHIS-ONDERZOEK">
         <xs:annotation>
             <xs:documentation>Nummer toegekend bij  het afmelden van het onderzoek in Archis2 van de Rijksdienst Cultureel Erfgoed.</xs:documentation>

--- a/lib/src/main/resources/vocab/identifier-type.xsd
+++ b/lib/src/main/resources/vocab/identifier-type.xsd
@@ -157,6 +157,20 @@
         </xs:simpleContent>
     </xs:complexType>
 
+    <xs:complexType name="EDNA-PROJECT">
+        <xs:annotation>
+            <xs:documentation>Deprecated. Use 'eDNA-project' instead.</xs:documentation>
+        </xs:annotation>
+        <xs:simpleContent>
+            <xs:restriction base="dc:SimpleLiteral">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string"/>
+                </xs:simpleType>
+                <xs:attribute ref="xml:lang" use="prohibited"/>
+            </xs:restriction>
+        </xs:simpleContent>
+    </xs:complexType>
+
     <xs:complexType name="ARCHIS-ONDERZOEK">
         <xs:annotation>
             <xs:documentation>Nummer toegekend bij  het afmelden van het onderzoek in Archis2 van de Rijksdienst Cultureel Erfgoed.</xs:documentation>


### PR DESCRIPTION
fixes EASY-2787

#### When applied it will
* Allow both EDNA-PROJECT as eDNA-project as id-type
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 
