### PR TITLE
DD-832: Put DC schema's in the 'extern' directory of easy-schema

### DIFF
--- a/lib/src/main/resources/bag/metadata/afm/2020/10/afm.xsd
+++ b/lib/src/main/resources/bag/metadata/afm/2020/10/afm.xsd
@@ -24,9 +24,9 @@
     <xs:import namespace="http://www.w3.org/XML/1998/namespace"
         schemaLocation="http://www.w3.org/2001/03/xml.xsd"/>
     <xs:import namespace="http://purl.org/dc/terms/"
-        schemaLocation="https://dublincore.org/schemas/xmls/qdc/dcterms.xsd"/>
+        schemaLocation="https://easy.dans.knaw.nl/schemas/extern/dcterms.xsd"/>
     <xs:import namespace="http://purl.org/dc/elements/1.1/"
-        schemaLocation="https://dublincore.org/schemas/xmls/qdc/dc.xsd"/>
+        schemaLocation="https://easy.dans.knaw.nl/schemas/extern/dc.xsd"/>
 
     <xs:element name="hardware" substitutionGroup="dcterms:description">
         <xs:annotation>

--- a/lib/src/main/resources/bag/metadata/afm/afm.xsd
+++ b/lib/src/main/resources/bag/metadata/afm/afm.xsd
@@ -24,9 +24,9 @@
     <xs:import namespace="http://www.w3.org/XML/1998/namespace"
         schemaLocation="http://www.w3.org/2001/03/xml.xsd"/>
     <xs:import namespace="http://purl.org/dc/terms/"
-        schemaLocation="https://dublincore.org/schemas/xmls/qdc/dcterms.xsd"/>
+        schemaLocation="https://easy.dans.knaw.nl/schemas/extern/dcterms.xsd"/>
     <xs:import namespace="http://purl.org/dc/elements/1.1/"
-        schemaLocation="https://dublincore.org/schemas/xmls/qdc/dc.xsd"/>
+        schemaLocation="https://easy.dans.knaw.nl/schemas/extern/dc.xsd"/>
 
     <xs:element name="hardware" substitutionGroup="dcterms:description">
         <xs:annotation>

--- a/lib/src/main/resources/bag/metadata/agreements/2021/11/agreements.xsd
+++ b/lib/src/main/resources/bag/metadata/agreements/2021/11/agreements.xsd
@@ -19,7 +19,7 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:dcterms="http://purl.org/dc/terms/" elementFormDefault="qualified"
            xmlns:am="http://easy.dans.knaw.nl/schemas/bag/metadata/agreements/"
            targetNamespace="http://easy.dans.knaw.nl/schemas/bag/metadata/agreements/">
-    <xs:import namespace="http://purl.org/dc/terms/" schemaLocation="https://dublincore.org/schemas/xmls/qdc/2008/02/11/dcterms.xsd"/>
+    <xs:import namespace="http://purl.org/dc/terms/" schemaLocation="https://easy.dans.knaw.nl/schemas/extern/dcterms.xsd"/>
     <xs:annotation>
         <xs:documentation>
             This schema specifies a metadata-format for describing the agreements between the depositor and DANS-KNAW.

--- a/lib/src/main/resources/bag/metadata/agreements/agreements.xsd
+++ b/lib/src/main/resources/bag/metadata/agreements/agreements.xsd
@@ -19,7 +19,7 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:dcterms="http://purl.org/dc/terms/" elementFormDefault="qualified"
            xmlns:am="http://easy.dans.knaw.nl/schemas/bag/metadata/agreements/"
            targetNamespace="http://easy.dans.knaw.nl/schemas/bag/metadata/agreements/">
-    <xs:import namespace="http://purl.org/dc/terms/" schemaLocation="https://dublincore.org/schemas/xmls/qdc/2008/02/11/dcterms.xsd"/>
+    <xs:import namespace="http://purl.org/dc/terms/" schemaLocation="https://easy.dans.knaw.nl/schemas/extern/dcterms.xsd"/>
     <xs:annotation>
         <xs:documentation>
             This schema specifies a metadata-format for describing the agreements between the depositor and DANS-KNAW.

--- a/lib/src/main/resources/bag/metadata/files/2020/06/files.xsd
+++ b/lib/src/main/resources/bag/metadata/files/2020/06/files.xsd
@@ -45,10 +45,8 @@
 
     <!-- =================================================================================== -->
     <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/03/xml.xsd"/>
-    <!-- this schema location is temporary, since the original (https://dublincore.org/schemas/xmls/qdc/dc.xsd) is not available -->
-    <xs:import namespace="http://purl.org/dc/elements/1.1/" schemaLocation="https://dublincore.org/schemas/xmls/qdc/2008/02/11/dc.xsd"/>
-    <!-- this schema location is temporary, since the original (https://dublincore.org/schemas/xmls/qdc/dcterms.xsd) is not available -->
-    <xs:import namespace="http://purl.org/dc/terms/" schemaLocation="https://dublincore.org/schemas/xmls/qdc/2008/02/11/dcterms.xsd"/>
+    <xs:import namespace="http://purl.org/dc/elements/1.1/" schemaLocation="https://easy.dans.knaw.nl/schemas/extern/dc.xsd"/>
+    <xs:import namespace="http://purl.org/dc/terms/" schemaLocation="https://easy.dans.knaw.nl/schemas/extern/dcterms.xsd"/>
     <xs:import namespace="http://easy.dans.knaw.nl/schemas/bag/metadata/afm/" schemaLocation="http://easy.dans.knaw.nl/schemas/bag/metadata/afm/afm.xsd"/>
     <!-- =================================================================================== -->
     <xs:element name="files">

--- a/lib/src/main/resources/bag/metadata/files/files.xsd
+++ b/lib/src/main/resources/bag/metadata/files/files.xsd
@@ -45,10 +45,8 @@
 
     <!-- =================================================================================== -->
     <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/03/xml.xsd"/>
-    <!-- this schema location is temporary, since the original (https://dublincore.org/schemas/xmls/qdc/dc.xsd) is not available -->
-    <xs:import namespace="http://purl.org/dc/elements/1.1/" schemaLocation="https://dublincore.org/schemas/xmls/qdc/2008/02/11/dc.xsd"/>
-    <!-- this schema location is temporary, since the original (https://dublincore.org/schemas/xmls/qdc/dcterms.xsd) is not available -->
-    <xs:import namespace="http://purl.org/dc/terms/" schemaLocation="https://dublincore.org/schemas/xmls/qdc/2008/02/11/dcterms.xsd"/>
+    <xs:import namespace="http://purl.org/dc/elements/1.1/" schemaLocation="https://easy.dans.knaw.nl/schemas/extern/dc.xsd"/>
+    <xs:import namespace="http://purl.org/dc/terms/" schemaLocation="https://easy.dans.knaw.nl/schemas/extern/dcterms.xsd"/>
     <xs:import namespace="http://easy.dans.knaw.nl/schemas/bag/metadata/afm/" schemaLocation="http://easy.dans.knaw.nl/schemas/bag/metadata/afm/afm.xsd"/>
     <!-- =================================================================================== -->
     <xs:element name="files">

--- a/lib/src/main/resources/bag/metadata/prov/2021/provenance.xsd
+++ b/lib/src/main/resources/bag/metadata/prov/2021/provenance.xsd
@@ -34,9 +34,9 @@
     <xs:import namespace="http://www.w3.org/XML/1998/namespace"
                schemaLocation="http://www.w3.org/2001/03/xml.xsd"/>
     <xs:import namespace="http://purl.org/dc/elements/1.1/"
-               schemaLocation="https://dublincore.org/schemas/xmls/qdc/dc.xsd"/>
+               schemaLocation="https://easy.dans.knaw.nl/schemas/extern/dc.xsd"/>
     <xs:import namespace="http://purl.org/dc/terms/"
-               schemaLocation="https://dublincore.org/schemas/xmls/qdc/dcterms.xsd"/>
+               schemaLocation="https://easy.dans.knaw.nl/schemas/extern/dcterms.xsd"/>
     <xs:import namespace="http://easy.dans.knaw.nl/schemas/dcx/"
                schemaLocation="http://easy.dans.knaw.nl/schemas/dcx/2012/10/dcx.xsd"/>
     <xs:import namespace="http://easy.dans.knaw.nl/schemas/dcx/dai/"

--- a/lib/src/main/resources/bag/metadata/prov/provenance.xsd
+++ b/lib/src/main/resources/bag/metadata/prov/provenance.xsd
@@ -34,9 +34,9 @@
     <xs:import namespace="http://www.w3.org/XML/1998/namespace"
                schemaLocation="http://www.w3.org/2001/03/xml.xsd"/>
     <xs:import namespace="http://purl.org/dc/elements/1.1/"
-               schemaLocation="https://dublincore.org/schemas/xmls/qdc/dc.xsd"/>
+               schemaLocation="https://easy.dans.knaw.nl/schemas/extern/dc.xsd"/>
     <xs:import namespace="http://purl.org/dc/terms/"
-               schemaLocation="https://dublincore.org/schemas/xmls/qdc/dcterms.xsd"/>
+               schemaLocation="https://easy.dans.knaw.nl/schemas/extern/dcterms.xsd"/>
     <xs:import namespace="http://easy.dans.knaw.nl/schemas/dcx/"
                schemaLocation="http://easy.dans.knaw.nl/schemas/dcx/2012/10/dcx.xsd"/>
     <xs:import namespace="http://easy.dans.knaw.nl/schemas/dcx/dai/"

--- a/lib/src/main/resources/collections/oai-dc.xsd
+++ b/lib/src/main/resources/collections/oai-dc.xsd
@@ -21,7 +21,7 @@
     xmlns:dc="http://purl.org/dc/elements/1.1/"
     targetNamespace="http://www.openarchives.org/OAI/2.0/oai_dc/">
 
-    <xs:import namespace="http://purl.org/dc/elements/1.1/" schemaLocation="http://easy.dans.knaw.nl/schemas/collections/dc.xsd"/>
+    <xs:import namespace="http://purl.org/dc/elements/1.1/" schemaLocation="https://easy.dans.knaw.nl/schemas/extern/dc.xsd"/>
 
     <xs:element name="dc" substitutionGroup="dc:dc"/>
     

--- a/lib/src/main/resources/dcx/2020/03/dcx-dai.xsd
+++ b/lib/src/main/resources/dcx/2020/03/dcx-dai.xsd
@@ -50,7 +50,7 @@
     <xs:import namespace="http://easy.dans.knaw.nl/schemas/dcx/"
                schemaLocation="http://easy.dans.knaw.nl/schemas/dcx/2012/10/dcx.xsd"/>
     <xs:import namespace="http://purl.org/dc/elements/1.1/"
-               schemaLocation="https://dublincore.org/schemas/xmls/qdc/dc.xsd"/>
+               schemaLocation="https://easy.dans.knaw.nl/schemas/extern/dc.xsd"/>
     <xs:import namespace="http://datacite.org/schema/kernel-4"
                schemaLocation="http://schema.datacite.org/meta/kernel-4/metadata.xsd"/>
 

--- a/lib/src/main/resources/dcx/dcx-dai.xsd
+++ b/lib/src/main/resources/dcx/dcx-dai.xsd
@@ -50,7 +50,7 @@
     <xs:import namespace="http://easy.dans.knaw.nl/schemas/dcx/"
                schemaLocation="http://easy.dans.knaw.nl/schemas/dcx/2012/10/dcx.xsd"/>
     <xs:import namespace="http://purl.org/dc/elements/1.1/"
-               schemaLocation="https://dublincore.org/schemas/xmls/qdc/dc.xsd"/>
+               schemaLocation="https://easy.dans.knaw.nl/schemas/extern/dc.xsd"/>
     <xs:import namespace="http://datacite.org/schema/kernel-4"
                schemaLocation="http://schema.datacite.org/meta/kernel-4/metadata.xsd"/>
 

--- a/lib/src/main/resources/dcx/dcx-gml.xsd
+++ b/lib/src/main/resources/dcx/dcx-gml.xsd
@@ -34,7 +34,7 @@
     <xs:import namespace="http://easy.dans.knaw.nl/schemas/dcx/"
                schemaLocation="http://easy.dans.knaw.nl/schemas/dcx/2012/10/dcx.xsd"/>
     <xs:import namespace="http://purl.org/dc/terms/"
-               schemaLocation="https://dublincore.org/schemas/xmls/qdc/dcterms.xsd"/>
+               schemaLocation="https://easy.dans.knaw.nl/schemas/extern/dcterms.xsd"/>
     <xs:import namespace="http://www.opengis.net/gml"
                schemaLocation="http://schemas.opengis.net/gml/3.1.1/profiles/gmlsfProfile/1.0.0/gmlsf.xsd"/>
 

--- a/lib/src/main/resources/extern/dc.xsd
+++ b/lib/src/main/resources/extern/dc.xsd
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns="http://purl.org/dc/elements/1.1/"
+           targetNamespace="http://purl.org/dc/elements/1.1/"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified">
+
+  <xs:annotation>
+    <xs:documentation xml:lang="en">
+      DCMES 1.1 XML Schema
+      XML Schema for http://purl.org/dc/elements/1.1/ namespace
+
+      Created 2008-02-11
+
+      Created by
+
+      Tim Cole (t-cole3@uiuc.edu)
+      Tom Habing (thabing@uiuc.edu)
+      Jane Hunter (jane@dstc.edu.au)
+      Pete Johnston (p.johnston@ukoln.ac.uk),
+      Carl Lagoze (lagoze@cs.cornell.edu)
+
+      This schema declares XML elements for the 15 DC elements from the
+      http://purl.org/dc/elements/1.1/ namespace.
+
+      It defines a complexType SimpleLiteral which permits mixed content
+      and makes the xml:lang attribute available. It disallows child elements by
+      use of minOcccurs/maxOccurs.
+
+      However, this complexType does permit the derivation of other complexTypes
+      which would permit child elements.
+
+      All elements are declared as substitutable for the abstract element any,
+      which means that the default type for all elements is dc:SimpleLiteral.
+
+    </xs:documentation>
+
+  </xs:annotation>
+
+
+  <xs:import namespace="http://www.w3.org/XML/1998/namespace"
+             schemaLocation="http://www.w3.org/2001/03/xml.xsd">
+  </xs:import>
+
+  <xs:complexType name="SimpleLiteral">
+    <xs:annotation>
+      <xs:documentation xml:lang="en">
+        This is the default type for all of the DC elements.
+        It permits text content only with optional
+        xml:lang attribute.
+        Text is allowed because mixed="true", but sub-elements
+        are disallowed because minOccurs="0" and maxOccurs="0"
+        are on the xs:any tag.
+
+        This complexType allows for restriction or extension permitting
+        child elements.
+      </xs:documentation>
+    </xs:annotation>
+
+    <xs:complexContent mixed="true">
+      <xs:restriction base="xs:anyType">
+        <xs:sequence>
+          <xs:any processContents="lax" minOccurs="0" maxOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute ref="xml:lang" use="optional"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:element name="any" type="SimpleLiteral" abstract="true"/>
+
+  <xs:element name="title" substitutionGroup="any"/>
+  <xs:element name="creator" substitutionGroup="any"/>
+  <xs:element name="subject" substitutionGroup="any"/>
+  <xs:element name="description" substitutionGroup="any"/>
+  <xs:element name="publisher" substitutionGroup="any"/>
+  <xs:element name="contributor" substitutionGroup="any"/>
+  <xs:element name="date" substitutionGroup="any"/>
+  <xs:element name="type" substitutionGroup="any"/>
+  <xs:element name="format" substitutionGroup="any"/>
+  <xs:element name="identifier" substitutionGroup="any"/>
+  <xs:element name="source" substitutionGroup="any"/>
+  <xs:element name="language" substitutionGroup="any"/>
+  <xs:element name="relation" substitutionGroup="any"/>
+  <xs:element name="coverage" substitutionGroup="any"/>
+  <xs:element name="rights" substitutionGroup="any"/>
+
+  <xs:group name="elementsGroup">
+    <xs:annotation>
+      <xs:documentation xml:lang="en">
+        This group is included as a convenience for schema authors
+        who need to refer to all the elements in the
+        http://purl.org/dc/elements/1.1/ namespace.
+      </xs:documentation>
+    </xs:annotation>
+
+    <xs:sequence>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="any"/>
+      </xs:choice>
+    </xs:sequence>
+  </xs:group>
+
+  <xs:complexType name="elementContainer">
+    <xs:annotation>
+      <xs:documentation xml:lang="en">
+        This complexType is included as a convenience for schema authors who need to define a root
+        or container element for all of the DC elements.
+      </xs:documentation>
+    </xs:annotation>
+
+    <xs:choice>
+      <xs:group ref="elementsGroup"/>
+    </xs:choice>
+  </xs:complexType>
+
+
+</xs:schema>
+        <!--#include virtual="/schemas/xmls/qdc/2008/02/11/dc.xsd" -->

--- a/lib/src/main/resources/extern/dcmitype.xsd
+++ b/lib/src/main/resources/extern/dcmitype.xsd
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://purl.org/dc/dcmitype/" elementFormDefault="qualified" attributeFormDefault="unqualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:annotation>
+    <xs:documentation xml:lang="en">
+      DCMI Type Vocabulary XML Schema XML Schema for http://purl.org/dc/dcmitype/ namespace Created 2008-02-11 Created by Tim Cole (t-cole3@uiuc.edu) Tom Habing (thabing@uiuc.edu) Jane Hunter (jane@dstc.edu.au) Pete Johnston (p.johnston@ukoln.ac.uk), Carl Lagoze (lagoze@cs.cornell.edu) This schema defines a simpleType which enumerates the allowable values for the DCMI Type Vocabulary.
+    </xs:documentation>
+  </xs:annotation>
+  <xs:simpleType name="DCMIType">
+    <xs:union>
+      <xs:simpleType>
+        <xs:restriction base="xs:Name">
+          <xs:enumeration value="Collection"/>
+          <xs:enumeration value="Dataset"/>
+          <xs:enumeration value="Event"/>
+          <xs:enumeration value="Image"/>
+          <xs:enumeration value="MovingImage"/>
+          <xs:enumeration value="StillImage"/>
+          <xs:enumeration value="InteractiveResource"/>
+          <xs:enumeration value="Service"/>
+          <xs:enumeration value="Software"/>
+          <xs:enumeration value="Sound"/>
+          <xs:enumeration value="Text"/>
+          <xs:enumeration value="PhysicalObject"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:union>
+  </xs:simpleType>
+</xs:schema>

--- a/lib/src/main/resources/extern/dcterms.xsd
+++ b/lib/src/main/resources/extern/dcterms.xsd
@@ -1,0 +1,383 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:dc="http://purl.org/dc/elements/1.1/"
+           xmlns:dcmitype="http://purl.org/dc/dcmitype/"
+           targetNamespace="http://purl.org/dc/terms/"
+           xmlns="http://purl.org/dc/terms/"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified">
+
+  <xs:annotation>
+    <xs:documentation xml:lang="en">
+      DCterms XML Schema
+      XML Schema for http://purl.org/dc/terms/ namespace
+
+      Created 2008-02-11
+
+      Created by
+
+      Tim Cole (t-cole3@uiuc.edu)
+      Tom Habing (thabing@uiuc.edu)
+      Jane Hunter (jane@dstc.edu.au)
+      Pete Johnston (p.johnston@ukoln.ac.uk),
+      Carl Lagoze (lagoze@cs.cornell.edu)
+
+      This schema declares XML elements for the DC elements and
+      DC element refinements from the http://purl.org/dc/terms/ namespace.
+
+      It reuses the complexType dc:SimpleLiteral, imported from the dc.xsd
+      schema, which permits simple element content, and makes the xml:lang
+      attribute available.
+
+      This complexType permits the derivation of other complexTypes
+      which would permit child elements.
+
+      XML elements corresponding to DC elements are declared as substitutable for the abstract element dc:any, and
+      XML elements corresponding to DC element refinements are defined as substitutable for the base elements
+      which they refine.
+
+      This means that the default type for all XML elements (i.e. corresponding to all DC elements and
+      element refinements) is dc:SimpleLiteral.
+
+      Encoding schemes are defined as complexTypes which are restrictions
+      of the dc:SimpleLiteral complexType. These complexTypes restrict
+      values to an appropriates syntax or format using data typing,
+      regular expressions, or enumerated lists.
+
+      In order to specify one of these encodings an xsi:type attribute must
+      be used in the instance document.
+
+      Also, note that one shortcoming of this approach is that any type can be
+      applied to any of the elements or refinements.  There is no convenient way
+      to restrict types to specific elements using this approach.
+
+      Changes in 2008-02-11 version:
+
+      Add element declarations corresponding to 15 new dcterms URIs, and amend use of substitutionGroups.
+
+      Add compexType definitions corresponding to ISO639-3, RFC4646.
+
+    </xs:documentation>
+
+  </xs:annotation>
+
+
+  <xs:import namespace="http://www.w3.org/XML/1998/namespace"
+             schemaLocation="http://www.w3.org/2001/03/xml.xsd">
+  </xs:import>
+
+  <xs:import namespace="http://purl.org/dc/elements/1.1/"
+             schemaLocation="dc.xsd"/>
+
+  <xs:import namespace="http://purl.org/dc/dcmitype/"
+             schemaLocation="dcmitype.xsd"/>
+
+  <xs:element name="title" substitutionGroup="dc:title"/>
+  <xs:element name="creator" substitutionGroup="dc:creator"/>
+  <xs:element name="subject" substitutionGroup="dc:subject"/>
+  <xs:element name="description" substitutionGroup="dc:description"/>
+  <xs:element name="publisher" substitutionGroup="dc:publisher"/>
+  <xs:element name="contributor" substitutionGroup="dc:contributor"/>
+  <xs:element name="date" substitutionGroup="dc:date"/>
+  <xs:element name="type" substitutionGroup="dc:type"/>
+  <xs:element name="format" substitutionGroup="dc:format"/>
+  <xs:element name="identifier" substitutionGroup="dc:identifier"/>
+  <xs:element name="source" substitutionGroup="dc:source"/>
+  <xs:element name="language" substitutionGroup="dc:language"/>
+  <xs:element name="relation" substitutionGroup="dc:relation"/>
+  <xs:element name="coverage" substitutionGroup="dc:coverage"/>
+  <xs:element name="rights" substitutionGroup="dc:rights"/>
+
+  <xs:element name="alternative" substitutionGroup="title"/>
+
+  <xs:element name="tableOfContents" substitutionGroup="description"/>
+  <xs:element name="abstract" substitutionGroup="description"/>
+
+  <xs:element name="created" substitutionGroup="date"/>
+  <xs:element name="valid" substitutionGroup="date"/>
+  <xs:element name="available" substitutionGroup="date"/>
+  <xs:element name="issued" substitutionGroup="date"/>
+  <xs:element name="modified" substitutionGroup="date"/>
+  <xs:element name="dateAccepted" substitutionGroup="date"/>
+  <xs:element name="dateCopyrighted" substitutionGroup="date"/>
+  <xs:element name="dateSubmitted" substitutionGroup="date"/>
+
+  <xs:element name="extent" substitutionGroup="format"/>
+  <xs:element name="medium" substitutionGroup="format"/>
+
+  <xs:element name="isVersionOf" substitutionGroup="relation"/>
+  <xs:element name="hasVersion" substitutionGroup="relation"/>
+  <xs:element name="isReplacedBy" substitutionGroup="relation"/>
+  <xs:element name="replaces" substitutionGroup="relation"/>
+  <xs:element name="isRequiredBy" substitutionGroup="relation"/>
+  <xs:element name="requires" substitutionGroup="relation"/>
+  <xs:element name="isPartOf" substitutionGroup="relation"/>
+  <xs:element name="hasPart" substitutionGroup="relation"/>
+  <xs:element name="isReferencedBy" substitutionGroup="relation"/>
+  <xs:element name="references" substitutionGroup="relation"/>
+  <xs:element name="isFormatOf" substitutionGroup="relation"/>
+  <xs:element name="hasFormat" substitutionGroup="relation"/>
+  <xs:element name="conformsTo" substitutionGroup="relation"/>
+
+  <xs:element name="spatial" substitutionGroup="coverage"/>
+  <xs:element name="temporal" substitutionGroup="coverage"/>
+
+  <xs:element name="audience" substitutionGroup="dc:any"/>
+  <xs:element name="accrualMethod" substitutionGroup="dc:any"/>
+  <xs:element name="accrualPeriodicity" substitutionGroup="dc:any"/>
+  <xs:element name="accrualPolicy" substitutionGroup="dc:any"/>
+  <xs:element name="instructionalMethod" substitutionGroup="dc:any"/>
+  <xs:element name="provenance" substitutionGroup="dc:any"/>
+  <xs:element name="rightsHolder" substitutionGroup="dc:any"/>
+
+  <xs:element name="mediator" substitutionGroup="audience"/>
+  <xs:element name="educationLevel" substitutionGroup="audience"/>
+
+  <xs:element name="accessRights" substitutionGroup="rights"/>
+  <xs:element name="license" substitutionGroup="rights"/>
+
+  <xs:element name="bibliographicCitation" substitutionGroup="identifier"/>
+
+  <xs:complexType name="LCSH">
+    <xs:simpleContent>
+      <xs:restriction base="dc:SimpleLiteral">
+        <xs:simpleType>
+          <xs:restriction base="xs:string"/>
+        </xs:simpleType>
+        <xs:attribute ref="xml:lang" use="prohibited"/>
+      </xs:restriction>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="MESH">
+    <xs:simpleContent>
+      <xs:restriction base="dc:SimpleLiteral">
+        <xs:simpleType>
+          <xs:restriction base="xs:string"/>
+        </xs:simpleType>
+        <xs:attribute ref="xml:lang" use="prohibited"/>
+      </xs:restriction>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="DDC">
+    <xs:simpleContent>
+      <xs:restriction base="dc:SimpleLiteral">
+        <xs:simpleType>
+          <xs:restriction base="xs:string"/>
+        </xs:simpleType>
+        <xs:attribute ref="xml:lang" use="prohibited"/>
+      </xs:restriction>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="LCC">
+    <xs:simpleContent>
+      <xs:restriction base="dc:SimpleLiteral">
+        <xs:simpleType>
+          <xs:restriction base="xs:string"/>
+        </xs:simpleType>
+        <xs:attribute ref="xml:lang" use="prohibited"/>
+      </xs:restriction>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="UDC">
+    <xs:simpleContent>
+      <xs:restriction base="dc:SimpleLiteral">
+        <xs:simpleType>
+          <xs:restriction base="xs:string"/>
+        </xs:simpleType>
+        <xs:attribute ref="xml:lang" use="prohibited"/>
+      </xs:restriction>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="Period">
+    <xs:simpleContent>
+      <xs:restriction base="dc:SimpleLiteral">
+        <xs:simpleType>
+          <xs:restriction base="xs:string"/>
+        </xs:simpleType>
+        <xs:attribute ref="xml:lang" use="prohibited"/>
+      </xs:restriction>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="W3CDTF">
+    <xs:simpleContent>
+      <xs:restriction base="dc:SimpleLiteral">
+        <xs:simpleType>
+          <xs:union memberTypes="xs:gYear xs:gYearMonth xs:date xs:dateTime"/>
+        </xs:simpleType>
+        <xs:attribute ref="xml:lang" use="prohibited"/>
+      </xs:restriction>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="DCMIType">
+    <xs:simpleContent>
+      <xs:restriction base="dc:SimpleLiteral">
+        <xs:simpleType>
+          <xs:restriction base="dcmitype:DCMIType"/>
+        </xs:simpleType>
+        <xs:attribute ref="xml:lang" use="prohibited"/>
+      </xs:restriction>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="IMT">
+    <xs:simpleContent>
+      <xs:restriction base="dc:SimpleLiteral">
+        <xs:simpleType>
+          <xs:restriction base="xs:string"/>
+        </xs:simpleType>
+        <xs:attribute ref="xml:lang" use="prohibited"/>
+      </xs:restriction>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="URI">
+    <xs:simpleContent>
+      <xs:restriction base="dc:SimpleLiteral">
+        <xs:simpleType>
+          <xs:restriction base="xs:anyURI"/>
+        </xs:simpleType>
+        <xs:attribute ref="xml:lang" use="prohibited"/>
+      </xs:restriction>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="ISO639-2">
+    <xs:simpleContent>
+      <xs:restriction base="dc:SimpleLiteral">
+        <xs:simpleType>
+          <xs:restriction base="xs:string"/>
+        </xs:simpleType>
+        <xs:attribute ref="xml:lang" use="prohibited"/>
+      </xs:restriction>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="ISO639-3">
+    <xs:simpleContent>
+      <xs:restriction base="dc:SimpleLiteral">
+        <xs:simpleType>
+          <xs:restriction base="xs:string"/>
+        </xs:simpleType>
+        <xs:attribute ref="xml:lang" use="prohibited"/>
+      </xs:restriction>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="RFC1766">
+    <xs:simpleContent>
+      <xs:restriction base="dc:SimpleLiteral">
+        <xs:simpleType>
+          <xs:restriction base="xs:language"/>
+        </xs:simpleType>
+        <xs:attribute ref="xml:lang" use="prohibited"/>
+      </xs:restriction>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="RFC3066">
+    <xs:simpleContent>
+      <xs:restriction base="dc:SimpleLiteral">
+        <xs:simpleType>
+          <xs:restriction base="xs:language"/>
+        </xs:simpleType>
+        <xs:attribute ref="xml:lang" use="prohibited"/>
+      </xs:restriction>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="RFC4646">
+    <xs:simpleContent>
+      <xs:restriction base="dc:SimpleLiteral">
+        <xs:simpleType>
+          <xs:restriction base="xs:language"/>
+        </xs:simpleType>
+        <xs:attribute ref="xml:lang" use="prohibited"/>
+      </xs:restriction>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="Point">
+    <xs:simpleContent>
+      <xs:restriction base="dc:SimpleLiteral">
+        <xs:simpleType>
+          <xs:restriction base="xs:string"/>
+        </xs:simpleType>
+        <xs:attribute ref="xml:lang" use="prohibited"/>
+      </xs:restriction>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="ISO3166">
+    <xs:simpleContent>
+      <xs:restriction base="dc:SimpleLiteral">
+        <xs:simpleType>
+          <xs:restriction base="xs:string"/>
+        </xs:simpleType>
+        <xs:attribute ref="xml:lang" use="prohibited"/>
+      </xs:restriction>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="Box">
+    <xs:simpleContent>
+      <xs:restriction base="dc:SimpleLiteral">
+        <xs:simpleType>
+          <xs:restriction base="xs:string"/>
+        </xs:simpleType>
+        <xs:attribute ref="xml:lang" use="prohibited"/>
+      </xs:restriction>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="TGN">
+    <xs:simpleContent>
+      <xs:restriction base="dc:SimpleLiteral">
+        <xs:simpleType>
+          <xs:restriction base="xs:string"/>
+        </xs:simpleType>
+        <xs:attribute ref="xml:lang" use="prohibited"/>
+      </xs:restriction>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:group name="elementsAndRefinementsGroup">
+    <xs:annotation>
+      <xs:documentation xml:lang="en">
+        This group is included as a convenience for schema authors
+        who need to refer to all the DC elements and element refinements
+        in the http://purl.org/dc/elements/1.1/ and
+        http://purl.org/dc/terms namespaces.
+        N.B. Refinements available via substitution groups.
+      </xs:documentation>
+    </xs:annotation>
+
+    <xs:sequence>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="dc:any" />
+      </xs:choice>
+    </xs:sequence>
+  </xs:group>
+
+  <xs:complexType name="elementOrRefinementContainer">
+    <xs:annotation>
+      <xs:documentation xml:lang="en">
+        This is included as a convenience for schema authors who need to define a root
+        or container element for all of the DC elements and element refinements.
+      </xs:documentation>
+    </xs:annotation>
+
+    <xs:choice>
+      <xs:group ref="elementsAndRefinementsGroup"/>
+    </xs:choice>
+  </xs:complexType>
+
+
+</xs:schema>
+        <!--#include virtual="/schemas/xmls/qdc/2008/02/11/dcterms.xsd" -->

--- a/lib/src/main/resources/md/2022/01/ddm.xsd
+++ b/lib/src/main/resources/md/2022/01/ddm.xsd
@@ -89,12 +89,10 @@
     <!-- =================================================================================== -->
     <xs:import namespace="http://www.w3.org/XML/1998/namespace"
                schemaLocation="http://www.w3.org/2001/03/xml.xsd"/>
-    <!-- this schema location is temporary, since the original (https://dublincore.org/schemas/xmls/qdc/dc.xsd) is not available -->
     <xs:import namespace="http://purl.org/dc/elements/1.1/"
-               schemaLocation="https://dublincore.org/schemas/xmls/qdc/2008/02/11/dc.xsd"/>
-    <!-- this schema location is temporary, since the original (https://dublincore.org/schemas/xmls/qdc/dcterms.xsd) is not available -->
+               schemaLocation="https://easy.dans.knaw.nl/schemas/extern/dc.xsd"/>
     <xs:import namespace="http://purl.org/dc/terms/"
-               schemaLocation="https://dublincore.org/schemas/xmls/qdc/2008/02/11/dcterms.xsd"/>
+               schemaLocation="https://easy.dans.knaw.nl/schemas/extern/dcterms.xsd"/>
     <xs:import namespace="http://easy.dans.knaw.nl/schemas/dcx/"
                schemaLocation="http://easy.dans.knaw.nl/schemas/dcx/2012/10/dcx.xsd"/>
     <xs:import namespace="http://easy.dans.knaw.nl/schemas/dcx/dai/"

--- a/lib/src/main/resources/md/ddm/ddm.xsd
+++ b/lib/src/main/resources/md/ddm/ddm.xsd
@@ -89,12 +89,10 @@
     <!-- =================================================================================== -->
     <xs:import namespace="http://www.w3.org/XML/1998/namespace"
                schemaLocation="http://www.w3.org/2001/03/xml.xsd"/>
-    <!-- this schema location is temporary, since the original (https://dublincore.org/schemas/xmls/qdc/dc.xsd) is not available -->
     <xs:import namespace="http://purl.org/dc/elements/1.1/"
-               schemaLocation="https://dublincore.org/schemas/xmls/qdc/2008/02/11/dc.xsd"/>
-    <!-- this schema location is temporary, since the original (https://dublincore.org/schemas/xmls/qdc/dcterms.xsd) is not available -->
+               schemaLocation="https://easy.dans.knaw.nl/schemas/extern/dc.xsd"/>
     <xs:import namespace="http://purl.org/dc/terms/"
-               schemaLocation="https://dublincore.org/schemas/xmls/qdc/2008/02/11/dcterms.xsd"/>
+               schemaLocation="https://easy.dans.knaw.nl/schemas/extern/dcterms.xsd"/>
     <xs:import namespace="http://easy.dans.knaw.nl/schemas/dcx/"
                schemaLocation="http://easy.dans.knaw.nl/schemas/dcx/2012/10/dcx.xsd"/>
     <xs:import namespace="http://easy.dans.knaw.nl/schemas/dcx/dai/"
@@ -174,8 +172,8 @@
     <!-- =================================================================================== -->
     <xs:element name="language" substitutionGroup="dc:language">
         <xs:annotation>
-            <xs:documentation>Restriction on dc:language. 
-                If used, the code attribute is required to record the language code 
+            <xs:documentation>Restriction on dc:language.
+                If used, the code attribute is required to record the language code
                 in either dcterms:ISO639-2 or dcterms:ISO639-3
             </xs:documentation>
         </xs:annotation>
@@ -188,7 +186,7 @@
             </xs:complexContent>
         </xs:complexType>
     </xs:element>
-    
+
     <xs:simpleType name="LanguageEncodingScheme">
         <xs:restriction base="xs:NMTOKEN">
             <xs:enumeration value="ISO639-2">
@@ -207,7 +205,7 @@
             </xs:enumeration>
         </xs:restriction>
     </xs:simpleType>
-    
+
     <!-- =================================================================================== -->
     <xs:element name="description" substitutionGroup="dc:description">
         <xs:annotation>
@@ -277,15 +275,15 @@
             </xs:documentation>
         </xs:annotation>
     </xs:element>
-    
+
     <!-- =================================================================================== -->
     <xs:element name="datesOfCollection" substitutionGroup="dcterms:date" type="id-type:RKMS-ISO8601">
         <xs:annotation>
             <xs:documentation xml:lang="en">
                 Restriction on dcterms:date to record the period the data was collected.
-                
+
                 Element value MUST conform to the id-type:RKMS-ISO8601 format.
-                
+
                 See also: http://purl.org/dc/terms/created
             </xs:documentation>
         </xs:annotation>
@@ -293,7 +291,7 @@
 
     <!-- =================================================================================== -->
     <xs:element name="funding" substitutionGroup="dcterms:contributor" type="ddm:FundingReferenceType"/>
-    
+
     <xs:complexType name="FundingReferenceType">
         <xs:complexContent>
             <xs:extension base="dcx:ElementsOnlyNoLanguageAttributeType">
@@ -304,7 +302,7 @@
                             <xs:simpleContent>
                                 <xs:extension base="xs:string">
                                     <xs:attribute name="funderIdentifierType"
-                                        type="datacite:funderIdentifierType" use="required"/>
+                                                  type="datacite:funderIdentifierType" use="required"/>
                                 </xs:extension>
                             </xs:simpleContent>
                         </xs:complexType>
@@ -313,7 +311,8 @@
                     <xs:element name="awardNumber" minOccurs="0">
                         <xs:annotation>
                             <xs:documentation>The code assigned by the funder to a sponsored award
-                                (grant).</xs:documentation>
+                                (grant).
+                            </xs:documentation>
                         </xs:annotation>
                         <xs:complexType>
                             <xs:simpleContent>
@@ -526,15 +525,15 @@
             </xs:documentation>
         </xs:annotation>
     </xs:element>
-    
+
     <!-- =================================================================================== -->
     <xs:element name="inCollection" substitutionGroup="dcterms:isPartOf" type="ddm:CollectionType">
         <xs:annotation>
             <xs:documentation xml:lang="en">Use this to describe the collection to which this dataset belongs.
             </xs:documentation>
-        </xs:annotation>        
+        </xs:annotation>
     </xs:element>
-    
+
     <xs:complexType name="CollectionType">
         <xs:complexContent>
             <xs:extension base="dc:SimpleLiteral">
@@ -556,7 +555,7 @@
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>
-    
+
     <!-- =================================================================================== -->
     <xs:element name="subject" substitutionGroup="dcterms:subject" type="ddm:SubjectType">
         <xs:annotation>

--- a/lib/src/main/resources/vocab/2021/03/identifier-type.xsd
+++ b/lib/src/main/resources/vocab/2021/03/identifier-type.xsd
@@ -24,7 +24,7 @@
     
     <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/03/xml.xsd"/> 
     
-    <xs:import namespace="http://purl.org/dc/elements/1.1/" schemaLocation="https://dublincore.org/schemas/xmls/qdc/dc.xsd"/>
+    <xs:import namespace="http://purl.org/dc/elements/1.1/" schemaLocation="https://easy.dans.knaw.nl/schemas/extern/dc.xsd"/>
     
     <xs:complexType name="DOI">
         <xs:simpleContent>

--- a/lib/src/main/resources/vocab/identifier-type.xsd
+++ b/lib/src/main/resources/vocab/identifier-type.xsd
@@ -24,7 +24,7 @@
     
     <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/03/xml.xsd"/> 
     
-    <xs:import namespace="http://purl.org/dc/elements/1.1/" schemaLocation="https://dublincore.org/schemas/xmls/qdc/dc.xsd"/>
+    <xs:import namespace="http://purl.org/dc/elements/1.1/" schemaLocation="https://easy.dans.knaw.nl/schemas/extern/dc.xsd"/>
     
     <xs:complexType name="DOI">
         <xs:simpleContent>

--- a/lib/src/main/resources/vocab/narcis-type.xsd
+++ b/lib/src/main/resources/vocab/narcis-type.xsd
@@ -39,7 +39,7 @@
     <xs:import namespace="http://www.w3.org/XML/1998/namespace"
         schemaLocation="http://www.w3.org/2001/03/xml.xsd"/>
     <xs:import namespace="http://purl.org/dc/elements/1.1/"
-        schemaLocation="https://dublincore.org/schemas/xmls/qdc/dc.xsd"/>
+        schemaLocation="https://easy.dans.knaw.nl/schemas/extern/dc.xsd"/>
 
     <xs:complexType name="DisciplineType">
         <xs:annotation>


### PR DESCRIPTION
fixes DD-832

#### When applied it will
* Add `dc.xsd`, `dcterms.xsd` and `dcmitype.xsd` into `extern` directory
* replace all `dublincore schema location` references to point to this directory


#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 
