### PR TITLE
DD-811: Add encoding element to ContentType

### DIFF
--- a/lib/src/main/resources/bag/metadata/amd/2022/02/amd.xsd
+++ b/lib/src/main/resources/bag/metadata/amd/2022/02/amd.xsd
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2012 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
+           targetNamespace="http://easy.dans.knaw.nl/easy/dataset-administrative-metadata/"
+           xmlns:damd="http://easy.dans.knaw.nl/easy/dataset-administrative-metadata/"
+           xmlns:wfs="http://easy.dans.knaw.nl/easy/workflow/">
+    <xs:import namespace="http://easy.dans.knaw.nl/easy/workflow/" schemaLocation="https://easy.dans.knaw.nl/schemas/bag/metadata/amd/wfs.xsd"/>
+    <!-- import the versioned schema of wfs -->
+    <xs:annotation>
+        <xs:documentation>
+            Schema to describe the administrative metadata for datasets in EASY, v1.0.
+            
+            Changes from 2021 to 2022:
+            * reintroduce: stateChangeDate
+            * Allow changeDate in stateChangeDate to be empty
+            Changes from 2018/02 to 2021:
+            * Make depositorId a standalone element
+            Changes from 2012 to 2018/02:
+            * delete: groupIds in the amd
+            * delete: datasetState/previousState no longer recorded, as state is not a property to be archived
+            * delete: stateChangeDates
+            * add: accessGranterId
+        </xs:documentation>
+    </xs:annotation>    
+    <xs:element name="administrative-md">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="damd:depositorId"/>
+                <xs:element name="accessGranterId" form="unqualified" type="xs:NCName" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The agent to be notified with questions regarding this dataset or its permissions.
+                            This is NOT necessarily the creator of the dataset.
+                            If no AccessGranter is specified, the depositor is notified.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element ref="damd:workflowData"/>
+            </xs:sequence>
+            <xs:attribute name="version" use="required" type="xs:string" fixed="1.0"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="stateChangeDate">
+        <xs:complexType>
+            <xs:sequence>                
+                <xs:element name="fromState" form="unqualified" type="xs:NCName"/>
+                <xs:element name="toState" form="unqualified" type="xs:NCName"/>
+                <xs:element name="changeDate" form="unqualified" type="damd:dateTime-or-nothing" />
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="depositorId" type="xs:NCName">
+        <xs:annotation>
+            <xs:documentation>The username of the depositor. This is NOT necessarily the creator of the dataset.</xs:documentation>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="workflowData">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="assigneeId" form="unqualified" type="xs:NCName">
+                    <xs:annotation>
+                        <xs:documentation>The DANS data manager responsible for the curation of this dataset.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element ref="wfs:workflow"/>
+            </xs:sequence>
+            <xs:attribute name="version" use="required" type="xs:string" fixed="1.0"/>
+        </xs:complexType>
+    </xs:element>   
+    
+    
+    <xs:simpleType name="empty-string">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value=""/>
+        </xs:restriction>
+    </xs:simpleType>
+    
+    <xs:simpleType name="dateTime-or-nothing">
+        <xs:union memberTypes="xs:dateTime damd:empty-string"/>
+    </xs:simpleType>       
+</xs:schema>

--- a/lib/src/main/resources/bag/metadata/amd/amd.xsd
+++ b/lib/src/main/resources/bag/metadata/amd/amd.xsd
@@ -25,7 +25,10 @@
     <xs:annotation>
         <xs:documentation>
             Schema to describe the administrative metadata for datasets in EASY, v1.0.
-
+            
+            Changes from 2021 to 2022:
+            * reintroduce: stateChangeDate
+            * Allow changeDate in stateChangeDate to be empty
             Changes from 2018/02 to 2021:
             * Make depositorId a standalone element
             Changes from 2012 to 2018/02:
@@ -34,7 +37,7 @@
             * delete: stateChangeDates
             * add: accessGranterId
         </xs:documentation>
-    </xs:annotation>
+    </xs:annotation>    
     <xs:element name="administrative-md">
         <xs:complexType>
             <xs:sequence>
@@ -51,6 +54,15 @@
                 <xs:element ref="damd:workflowData"/>
             </xs:sequence>
             <xs:attribute name="version" use="required" type="xs:string" fixed="1.0"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="stateChangeDate">
+        <xs:complexType>
+            <xs:sequence>                
+                <xs:element name="fromState" form="unqualified" type="xs:NCName"/>
+                <xs:element name="toState" form="unqualified" type="xs:NCName"/>
+                <xs:element name="changeDate" form="unqualified" type="damd:dateTime-or-nothing" />
+            </xs:sequence>
         </xs:complexType>
     </xs:element>
     <xs:element name="depositorId" type="xs:NCName">
@@ -70,5 +82,16 @@
             </xs:sequence>
             <xs:attribute name="version" use="required" type="xs:string" fixed="1.0"/>
         </xs:complexType>
-    </xs:element>
+    </xs:element>   
+    
+    
+    <xs:simpleType name="empty-string">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value=""/>
+        </xs:restriction>
+    </xs:simpleType>
+    
+    <xs:simpleType name="dateTime-or-nothing">
+        <xs:union memberTypes="xs:dateTime damd:empty-string"/>
+    </xs:simpleType>       
 </xs:schema>

--- a/lib/src/main/resources/bag/metadata/prov/2022/02/provenance.xsd
+++ b/lib/src/main/resources/bag/metadata/prov/2022/02/provenance.xsd
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2012 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:prov="http://easy.dans.knaw.nl/schemas/bag/metadata/prov/"
+           xmlns:ddm="http://easy.dans.knaw.nl/schemas/md/ddm/"
+           xmlns:amd="http://easy.dans.knaw.nl/easy/dataset-administrative-metadata/"
+           xmlns:dc="http://purl.org/dc/elements/1.1/"
+           xmlns:dcterms="http://purl.org/dc/terms/"
+           xmlns:dcx="http://easy.dans.knaw.nl/schemas/dcx/"
+           xmlns:dcx-dai="http://easy.dans.knaw.nl/schemas/dcx/dai/"
+           xmlns:narcis="http://easy.dans.knaw.nl/schemas/vocab/narcis-type/"
+           xmlns:id-type="http://easy.dans.knaw.nl/schemas/vocab/identifier-type/"
+           xmlns:datacite="http://datacite.org/schema/kernel-4"
+           targetNamespace="http://easy.dans.knaw.nl/schemas/bag/metadata/prov/"
+           elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+    <!-- =================================================================================== -->
+    <xs:import namespace="http://www.w3.org/XML/1998/namespace"
+               schemaLocation="http://www.w3.org/2001/03/xml.xsd"/>
+    <xs:import namespace="http://purl.org/dc/elements/1.1/"
+               schemaLocation="https://dublincore.org/schemas/xmls/qdc/dc.xsd"/>
+    <xs:import namespace="http://purl.org/dc/terms/"
+               schemaLocation="https://dublincore.org/schemas/xmls/qdc/dcterms.xsd"/>
+    <xs:import namespace="http://easy.dans.knaw.nl/schemas/dcx/"
+               schemaLocation="http://easy.dans.knaw.nl/schemas/dcx/2012/10/dcx.xsd"/>
+    <xs:import namespace="http://easy.dans.knaw.nl/schemas/dcx/dai/"
+               schemaLocation="http://easy.dans.knaw.nl/schemas/dcx/2020/03/dcx-dai.xsd"/>
+    <xs:import namespace="http://easy.dans.knaw.nl/schemas/md/ddm/"
+               schemaLocation="http://easy.dans.knaw.nl/schemas/md/ddm/ddm.xsd"/>
+    <xs:import namespace="http://easy.dans.knaw.nl/schemas/vocab/narcis-type/"
+               schemaLocation="http://easy.dans.knaw.nl/schemas/vocab/2015/narcis-type.xsd"/>
+    <xs:import namespace="http://easy.dans.knaw.nl/schemas/vocab/identifier-type/"
+               schemaLocation="http://easy.dans.knaw.nl/schemas/vocab/identifier-type.xsd"/>
+    <xs:import namespace="http://www.den.nl/standaard/166/Archeologisch-Basisregister/"
+               schemaLocation="http://easy.dans.knaw.nl/schemas/vocab/2012/abr-type.xsd"/>
+    <xs:import namespace="http://easy.dans.knaw.nl/schemas/dcx/gml/"
+               schemaLocation="http://easy.dans.knaw.nl/schemas/dcx/2016/dcx-gml.xsd"/>
+    <xs:import namespace="http://datacite.org/schema/kernel-4"
+               schemaLocation="http://schema.datacite.org/meta/kernel-4.1/metadata.xsd"/>
+    <xs:import namespace="http://easy.dans.knaw.nl/easy/dataset-administrative-metadata/"
+               schemaLocation="http://easy.dans.knaw.nl/schemas/bag/metadata/amd/amd.xsd"/>
+    <!-- =================================================================================== -->
+
+    <xs:annotation><xs:documentation>
+        changes since 2021-11
+        * Add filename attribute to prov:file element
+        * Add stateChangeDate element to ContentType
+        * Add encoding element to ContentType
+    </xs:documentation></xs:annotation>
+    <xs:element name="provenance">
+        <xs:complexType>
+            <xs:choice>
+                <xs:element ref="prov:migration"/>
+            </xs:choice>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="file">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="prov:old"/>
+                <xs:element ref="prov:new"/>
+            </xs:sequence>
+            <xs:attribute name="scheme" type="prov:XmlFileScheme"/>
+            <xs:attribute name="filename" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="migration">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="prov:file" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="app" use="required" type="xs:NCName"/>
+            <xs:attribute name="version" use="required" type="xs:NMTOKEN"/>
+            <xs:attribute name="date" use="required" type="xs:date"></xs:attribute>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="old" type="prov:ContentType"/>
+    <xs:element name="new" type="prov:ContentType"/>
+    <xs:simpleType name="XmlFileScheme">
+        <xs:restriction base="xs:anyURI">
+            <xs:enumeration value="http://easy.dans.knaw.nl/schemas/md/ddm/">
+                <xs:annotation>
+                    <xs:documentation>
+                        The DANS Dataset Metadata scheme
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="http://easy.dans.knaw.nl/easy/dataset-administrative-metadata/">
+                <xs:annotation>
+                    <xs:documentation>
+                        The EASY Administrative Metadata scheme
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:complexType name="ContentType">
+        <xs:complexContent>
+            <xs:extension base="dcterms:elementOrRefinementContainer">
+                <xs:choice>
+                    <xs:element ref="amd:depositorId" minOccurs="0"/>
+                    <xs:element ref="amd:stateChangeDate" minOccurs="0"/>
+                    <xs:element name="encoding" type="xs:string" minOccurs="0"/>
+                </xs:choice>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>    
+</xs:schema>

--- a/lib/src/main/resources/bag/metadata/prov/2022/02/provenance.xsd
+++ b/lib/src/main/resources/bag/metadata/prov/2022/02/provenance.xsd
@@ -34,9 +34,9 @@
     <xs:import namespace="http://www.w3.org/XML/1998/namespace"
                schemaLocation="http://www.w3.org/2001/03/xml.xsd"/>
     <xs:import namespace="http://purl.org/dc/elements/1.1/"
-               schemaLocation="https://dublincore.org/schemas/xmls/qdc/dc.xsd"/>
+               schemaLocation="http://easy.dans.knaw.nl/schemas/extern/dc.xsd"/>
     <xs:import namespace="http://purl.org/dc/terms/"
-               schemaLocation="https://dublincore.org/schemas/xmls/qdc/dcterms.xsd"/>
+               schemaLocation="http://easy.dans.knaw.nl/schemas/extern/dcterms.xsd"/>
     <xs:import namespace="http://easy.dans.knaw.nl/schemas/dcx/"
                schemaLocation="http://easy.dans.knaw.nl/schemas/dcx/2012/10/dcx.xsd"/>
     <xs:import namespace="http://easy.dans.knaw.nl/schemas/dcx/dai/"

--- a/lib/src/main/resources/bag/metadata/prov/provenance.xsd
+++ b/lib/src/main/resources/bag/metadata/prov/provenance.xsd
@@ -54,9 +54,15 @@
     <xs:import namespace="http://datacite.org/schema/kernel-4"
                schemaLocation="http://schema.datacite.org/meta/kernel-4.1/metadata.xsd"/>
     <xs:import namespace="http://easy.dans.knaw.nl/easy/dataset-administrative-metadata/"
-               schemaLocation="http://easy.dans.knaw.nl/schemas/bag/metadata/afm/afm.xsd"/>
+               schemaLocation="http://easy.dans.knaw.nl/schemas/bag/metadata/amd/amd.xsd"/>
     <!-- =================================================================================== -->
 
+    <xs:annotation><xs:documentation>
+        changes since 2021-11
+        * Add filename attribute to prov:file element
+        * Add stateChangeDate element to ContentType
+        * Add encoding element to ContentType
+    </xs:documentation></xs:annotation>
     <xs:element name="provenance">
         <xs:complexType>
             <xs:choice>
@@ -71,6 +77,7 @@
                 <xs:element ref="prov:new"/>
             </xs:sequence>
             <xs:attribute name="scheme" type="prov:XmlFileScheme"/>
+            <xs:attribute name="filename" type="xs:string" use="optional"/>
         </xs:complexType>
     </xs:element>
 
@@ -110,8 +117,10 @@
             <xs:extension base="dcterms:elementOrRefinementContainer">
                 <xs:choice>
                     <xs:element ref="amd:depositorId" minOccurs="0"/>
+                    <xs:element ref="amd:stateChangeDate" minOccurs="0"/>
+                    <xs:element name="encoding" type="xs:string" minOccurs="0"/>
                 </xs:choice>
             </xs:extension>
         </xs:complexContent>
-    </xs:complexType>
+    </xs:complexType>    
 </xs:schema>


### PR DESCRIPTION
fixes DD-811

#### When applied it will
* Add filename attribute to prov:file element (provenance.xsd)
* Add stateChangeDate element to ContentType (provenance.xsd)
* Add encoding element to ContentType (provenance.xsd)
* reintroduce: stateChangeDate (amd.xsd)
* Allow changeDate in stateChangeDate to be empty (amd.xsd)

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-convert-bag-to-deposit                      | [PR#79](https://github.com/DANS-KNAW/easy-convert-bag-to-deposit/pull/79) 
