### PR TITLE
DD-1140 allow cdata in provenance.old

### DIFF
--- a/lib/src/main/resources/bag/metadata/prov/2022/09/provenance.xsd
+++ b/lib/src/main/resources/bag/metadata/prov/2022/09/provenance.xsd
@@ -63,7 +63,6 @@
         * Add stateChangeDate element to ContentType
         * Add encoding element to ContentType
         changes since 2022-02
-        * Allow empty eas:role in contributor
         changes since 2021-06
         * allow CDATA in prov:old
     </xs:documentation></xs:annotation>


### PR DESCRIPTION
fixes DD-1140 allow cdata in provenance.old

#### When applied it will
* allow CDATA in provenance
* figured out previous release notes
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
* required by https://github.com/DANS-KNAW/easy-convert-bag-to-deposit/pull/102
